### PR TITLE
ci(docs): :rocket: add docs deployment on main when changed

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,3 +34,17 @@ jobs:
 
       - name: Upload code coverage
         uses: codecov/codecov-action@v3
+
+      - name: Authenticate SSH deploy key
+        uses: webfactory/ssh-agent@v0.5.0
+        with:
+          ssh-private-key: ${{ secrets.GH_PAGES_DEPLOY }}
+      
+      - name: Deploy doc
+        env:
+          USE_SSH: true
+          DEPLOYMENT_BRANCH: main
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "gh-actions"
+          yarn lerna run deploy --scope=@bonfhir/docs --since=HEAD^1


### PR DESCRIPTION
## What is this about

This PR adds automatic deployment of the docs site on the main merge.
See https://docusaurus.io/docs/deployment#triggering-deployment-with-github-actions for more details.

## Issue ticket numbers

N/A

## How can this be tested?

Unfortunately, can only be tested properly when running on GH actions. This may be painful.

## Known limitations/edge cases

N/A