### PR TITLE
Update trim version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "resolutions": {
     "got": ">=11.8.5",
     "highlight.js": ">=10.4.1",
-    "semver-regex": ">=3.1.3"
+    "semver-regex": ">=3.1.3",
+    "trim": ">=0.0.3"
   }
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -12,7 +12,7 @@
     "deploy": "docusaurus deploy",
     "dev": "docusaurus start --port 4000",
     "docusaurus": "docusaurus",
-    "serve": "docusaurus serve --dir dist",
+    "serve": "docusaurus serve --dir dist --port 4000",
     "swizzle": "docusaurus swizzle",
     "write-heading-ids": "docusaurus write-heading-ids",
     "write-translations": "docusaurus write-translations"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18304,10 +18304,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"trim@npm:0.0.1":
-  version: 0.0.1
-  resolution: "trim@npm:0.0.1"
-  checksum: 2b4646dff99a222e8e1526edd4e3a43bbd925af0b8e837c340455d250157e7deefaa4da49bb891ab841e5c27b1afc5e9e32d4b57afb875d2dfcabf4e319b8f7f
+"trim@npm:>=0.0.3":
+  version: 1.0.1
+  resolution: "trim@npm:1.0.1"
+  checksum: d7593f72edc1738218e94deeff54a9b81cb52b6448ef8a4d20015bd4581dadc3a636553fb06b1ab36d14e3803fd3138bd2b6da555de926abed33b0ae24f92879
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What is this about

This PR bumps the version for the `trim` package to `0.0.3` to address CVE-2020-7753.

## Issue ticket numbers

https://github.com/bonfhir/bonfhir/security/dependabot/8

## How can this be tested?

N/A

## Known limitations/edge cases

N/A
