### PR TITLE
feat(core): :sparkles: add decorateFhirRestfulClient helper

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,7 @@
     "vscode": {
       "extensions": [
         "andrejunges.Handlebars",
+        "cschleiden.vscode-github-actions",
         "dbaeumer.vscode-eslint",
         "eamodio.gitlens",
         "EditorConfig.EditorConfig",
@@ -17,9 +18,7 @@
         "nrwl.angular-console",
         "streetsidesoftware.code-spell-checker",
         "usernamehw.errorlens",
-        "vivaxy.vscode-conventional-commits",
-        "wmaurer.change-case",
-        "cschleiden.vscode-github-actions"
+        "vivaxy.vscode-conventional-commits"
       ],
       "settings": {
         "[javascript]": {
@@ -76,6 +75,8 @@
           "fhirpath",
           "Listr",
           "listr",
+          "medplum",
+          "Medplum",
           "Referenceable"
         ],
         "errorLens.enabledDiagnosticLevels": ["error", "warning"],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,7 @@
     "@types/rimraf": "^3",
     "eslint": "^8.30.0",
     "jest": "^29.3.1",
+    "jest-mock-extended": "^3.0.1",
     "prettier": "^2.8.1",
     "rimraf": "^3.0.2",
     "typescript": "^4.9.4"

--- a/packages/core/r4b/fhir-restful-client.test.ts
+++ b/packages/core/r4b/fhir-restful-client.test.ts
@@ -1,0 +1,39 @@
+import { mock } from "jest-mock-extended";
+import { build } from "./builders";
+import {
+  decorateFhirRestfulClient,
+  FhirRestfulClient,
+} from "./fhir-restful-client";
+
+describe("fhir-restful-client", () => {
+  it("delegates to client method on empty", async () => {
+    const client = mock<FhirRestfulClient>();
+    const readValue = build("Patient", {});
+    client.read.calledWith("Patient", "12345").mockResolvedValueOnce(readValue);
+
+    const decoratedClient = decorateFhirRestfulClient(client, {});
+    const result = await decoratedClient.read("Patient", "12345");
+
+    expect(result).toBe(readValue);
+    expect(client.read).toHaveBeenCalled();
+  });
+
+  it("intercept client method on empty", async () => {
+    const client = mock<FhirRestfulClient>();
+    const readValue = build("Patient", {});
+    const interceptedValue = build("Patient", {});
+    client.read.calledWith("Patient", "12345").mockResolvedValueOnce(readValue);
+
+    const decoratedClient = decorateFhirRestfulClient(client, {
+      read: async (_, [type, id]) => {
+        expect(type).toEqual("Patient");
+        expect(id).toEqual("12345");
+        return interceptedValue;
+      },
+    });
+    const result = await decoratedClient.read("Patient", "12345");
+
+    expect(result).toBe(interceptedValue);
+    expect(client.read).not.toHaveBeenCalled();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1709,6 +1709,7 @@ __metadata:
     fhirpath: ^3.3.1
     html-entities: ^2.3.3
     jest: ^29.3.1
+    jest-mock-extended: ^3.0.1
     prettier: ^2.8.1
     rimraf: ^3.0.2
     typescript: ^4.9.4
@@ -12426,6 +12427,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-mock-extended@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "jest-mock-extended@npm:3.0.1"
+  dependencies:
+    ts-essentials: ^7.0.3
+  peerDependencies:
+    jest: ^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0
+    typescript: ^3.0.0 || ^4.0.0
+  checksum: 8004e6fe538aa80e8e42faf62aa7c76dae1fd23b3f248cf1e428eca0dc8e3315a5f72b075484a5474983d3c4adf421c2064743d5a8c3a1e58a96ef5c59d8159a
+  languageName: node
+  linkType: hard
+
 "jest-mock@npm:^29.3.1":
   version: 29.3.1
   resolution: "jest-mock@npm:29.3.1"
@@ -18383,6 +18396,15 @@ __metadata:
   version: 1.0.5
   resolution: "trough@npm:1.0.5"
   checksum: d6c8564903ed00e5258bab92134b020724dbbe83148dc72e4bf6306c03ed8843efa1bcc773fa62410dd89161ecb067432dd5916501793508a9506cacbc408e25
+  languageName: node
+  linkType: hard
+
+"ts-essentials@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "ts-essentials@npm:7.0.3"
+  peerDependencies:
+    typescript: ">=3.7.0"
+  checksum: 74d75868acf7f8b95e447d8b3b7442ca21738c6894e576df9917a352423fde5eb43c5651da5f78997da6061458160ae1f6b279150b42f47ccc58b73e55acaa2f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What is this about

This PR introduces a way to intercept calls made to a `FhirRestfulClient`. Can be useful to log all calls made, for example.
In turn, removed the log interceptor in medplum adapter, which can be conveniently replaced by this.

## Issue ticket numbers

N/A

## How can this be tested?

Unit tests added.

## Known limitations/edge cases

N/A