### PR TITLE
fix(core): :adhesive_bandage: add `title` and `url` to `resourceSearch("ConceptMap")`

### DIFF
--- a/fhir/r4b/definitions/search-parameters.json
+++ b/fhir/r4b/definitions/search-parameters.json
@@ -18220,6 +18220,96 @@
       }
     },
     {
+      "fullUrl": "http://hl7.org/fhir/SearchParameter/ConceptMap-title",
+      "resource": {
+        "resourceType": "SearchParameter",
+        "id": "ConceptMap-title",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+            "valueCode": "trial-use"
+          }
+        ],
+        "url": "http://hl7.org/fhir/SearchParameter/ConceptMap-title",
+        "version": "4.3.0",
+        "name": "title",
+        "status": "draft",
+        "experimental": false,
+        "date": "2022-05-28T12:47:40+10:00",
+        "publisher": "Health Level Seven International (Vocabulary)",
+        "contact": [
+          {
+            "telecom": [
+              {
+                "system": "url",
+                "value": "http://hl7.org/fhir"
+              }
+            ]
+          },
+          {
+            "telecom": [
+              {
+                "system": "url",
+                "value": "http://www.hl7.org/Special/committees/Vocab/index.cfm"
+              }
+            ]
+          }
+        ],
+        "description": "The human-friendly name of the concept map",
+        "code": "title",
+        "base": ["ConceptMap"],
+        "type": "string",
+        "expression": "ConceptMap.title",
+        "xpath": "f:ConceptMap/f:title",
+        "xpathUsage": "normal"
+      }
+    },
+    {
+      "fullUrl": "http://hl7.org/fhir/SearchParameter/ConceptMap-url",
+      "resource": {
+        "resourceType": "SearchParameter",
+        "id": "ConceptMap-url",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+            "valueCode": "trial-use"
+          }
+        ],
+        "url": "http://hl7.org/fhir/SearchParameter/ConceptMap-url",
+        "version": "4.3.0",
+        "name": "url",
+        "status": "draft",
+        "experimental": false,
+        "date": "2022-05-28T12:47:40+10:00",
+        "publisher": "Health Level Seven International (Vocabulary)",
+        "contact": [
+          {
+            "telecom": [
+              {
+                "system": "url",
+                "value": "http://hl7.org/fhir"
+              }
+            ]
+          },
+          {
+            "telecom": [
+              {
+                "system": "url",
+                "value": "http://www.hl7.org/Special/committees/Vocab/index.cfm"
+              }
+            ]
+          }
+        ],
+        "description": "The uri that identifies the concept map",
+        "code": "url",
+        "base": ["ConceptMap"],
+        "type": "uri",
+        "expression": "ConceptMap.url",
+        "xpath": "f:ConceptMap/f:url",
+        "xpathUsage": "normal"
+      }
+    },
+    {
       "fullUrl": "http://hl7.org/fhir/SearchParameter/Condition-abatement-age",
       "resource": {
         "resourceType": "SearchParameter",

--- a/packages/core/r4b/resource-search.ts
+++ b/packages/core/r4b/resource-search.ts
@@ -15995,6 +15995,28 @@ class ResourceSearchBuilderConceptMap {
     this.builder.reference("target-uri", id, modifier);
     return this;
   }
+
+  /**
+   * The human-friendly name of the concept map
+   */
+  title(
+    value: string | string[] | null | undefined,
+    modifier?: StringModifier | null | undefined
+  ): ResourceSearchBuilderConceptMap {
+    this.builder.string("title", value, modifier);
+    return this;
+  }
+
+  /**
+   * The uri that identifies the concept map
+   */
+  url(
+    value: string | URL | Array<string | URL> | null | undefined,
+    modifier?: UriModifier | null | undefined
+  ): ResourceSearchBuilderConceptMap {
+    this.builder.uri("url", value, modifier);
+    return this;
+  }
 }
 
 class ResourceSearchBuilderCondition {


### PR DESCRIPTION
## What is this about

add `title` and `url` to `resourceSearch("ConceptMap")`

## Issue ticket numbers

fix #29

## How can this be tested?

N/A

## Known limitations/edge cases

N/A