### PR TITLE
Feat: buildTimelineOfResourcesWithPeriods

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "@types/fhir": "^0.0.35",
     "@types/node": "^18.11.18",
     "@types/rimraf": "^3",
+    "date-fns": "^2.29.3",
     "eslint": "^8.30.0",
     "jest": "^29.3.1",
     "jest-mock-extended": "^3.0.1",

--- a/packages/core/r4b/builders.ts
+++ b/packages/core/r4b/builders.ts
@@ -118,3 +118,24 @@ export function buildReferenceFromResource(
     type: resource.resourceType,
   };
 }
+
+/**
+ * Extract the id portion of a `Reference.reference`.
+ */
+export function getIdFromReference(reference: Reference): string | undefined;
+export function getIdFromReference(reference: null | undefined): undefined;
+export function getIdFromReference(
+  reference: Reference | null | undefined
+): string | undefined;
+export function getIdFromReference(
+  reference: Reference | null | undefined
+): string | undefined {
+  if (!reference?.reference) {
+    return undefined;
+  }
+
+  const splittedRef = reference.reference.split("/");
+  return splittedRef.length === 1
+    ? splittedRef[0]
+    : splittedRef.slice(1).join("/");
+}

--- a/packages/core/r4b/index.ts
+++ b/packages/core/r4b/index.ts
@@ -4,6 +4,7 @@ export * from "./date";
 export * from "./fhir-restful-client";
 export * from "./merge";
 export * from "./narratives";
+export * from "./period-calculator";
 export * from "./resource-search";
 export * from "./search-builder";
 export * from "./types";

--- a/packages/core/r4b/period-calculator.test.ts
+++ b/packages/core/r4b/period-calculator.test.ts
@@ -1,0 +1,250 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { addDays } from "date-fns";
+import { MedicationDispense, Period } from "fhir/r4";
+import { build } from "./builders";
+import {
+  buildTimelineOfResourcesWithPeriods,
+  Timeline,
+} from "./period-calculator";
+import { WithRequired } from "./types";
+
+describe("period-calculator", () => {
+  it("compute timeline of empty resources", () => {
+    const result = buildTimelineOfResourcesWithPeriods({
+      resources: [],
+      periodFn: () => ({ start: "", end: "" }),
+    });
+
+    expect(result.blocks.length).toBe(0);
+  });
+
+  it("compute timeline of 1 resource", () => {
+    const resources = [
+      build("MedicationDispense", {
+        status: "completed",
+        daysSupply: { value: 30 },
+        whenHandedOver: "2021-01-01",
+      }),
+    ];
+    const result = buildTimelineOfResourcesWithPeriods({
+      resources,
+      periodFn: medicationDispensePeriodFn,
+    });
+
+    expect(result).toMatchObject(<Timeline<MedicationDispense>>{
+      blocks: [
+        {
+          period: {
+            start: "2021-01-01",
+            end: "2021-01-31",
+          },
+          items: resources,
+        },
+      ],
+    });
+  });
+
+  it("compute timeline of 2 resources with same time", () => {
+    const resources = [
+      build("MedicationDispense", {
+        status: "completed",
+        daysSupply: { value: 30 },
+        whenHandedOver: "2021-01-01",
+      }),
+      build("MedicationDispense", {
+        status: "completed",
+        daysSupply: { value: 30 },
+        whenHandedOver: "2021-01-01",
+      }),
+    ];
+    const result = buildTimelineOfResourcesWithPeriods({
+      resources,
+      periodFn: medicationDispensePeriodFn,
+    });
+
+    expect(result).toMatchObject(<Timeline<MedicationDispense>>{
+      blocks: [
+        {
+          period: {
+            start: "2021-01-01",
+            end: "2021-01-31",
+          },
+          items: resources,
+        },
+      ],
+    });
+  });
+
+  it("compute timeline of 2 resources no overlap", () => {
+    const resources = [
+      build("MedicationDispense", {
+        status: "completed",
+        daysSupply: { value: 30 },
+        whenHandedOver: "2021-01-01",
+      }),
+      build("MedicationDispense", {
+        status: "completed",
+        daysSupply: { value: 30 },
+        whenHandedOver: "2021-02-01",
+      }),
+    ];
+    const result = buildTimelineOfResourcesWithPeriods({
+      resources,
+      periodFn: medicationDispensePeriodFn,
+    });
+
+    expect(result).toMatchObject(<Timeline<MedicationDispense>>{
+      blocks: [
+        {
+          period: {
+            start: "2021-01-01",
+            end: "2021-01-31",
+          },
+          items: [resources[0]],
+        },
+        {
+          period: {
+            start: "2021-02-01",
+            end: "2021-03-03",
+          },
+          items: [resources[1]],
+        },
+      ],
+    });
+  });
+
+  it("compute timeline of 2 resources with overlap", () => {
+    const resources = [
+      build("MedicationDispense", {
+        status: "completed",
+        daysSupply: { value: 30 },
+        whenHandedOver: "2021-01-01",
+      }),
+      build("MedicationDispense", {
+        status: "completed",
+        daysSupply: { value: 30 },
+        whenHandedOver: "2021-01-15",
+      }),
+    ];
+    const result = buildTimelineOfResourcesWithPeriods({
+      resources,
+      periodFn: medicationDispensePeriodFn,
+    });
+
+    expect(result).toMatchObject(<Timeline<MedicationDispense>>{
+      blocks: [
+        {
+          period: {
+            start: "2021-01-01",
+            end: "2021-01-15",
+          },
+          items: [resources[0]],
+        },
+        {
+          period: {
+            start: "2021-01-15",
+            end: "2021-01-31",
+          },
+          items: [resources[0], resources[1]],
+        },
+        {
+          period: {
+            start: "2021-01-31",
+            end: "2021-02-14",
+          },
+          items: [resources[1]],
+        },
+      ],
+    });
+  });
+
+  it("compute timeline of multiple resources with overlap", () => {
+    const resources = [
+      build("MedicationDispense", {
+        status: "completed",
+        daysSupply: { value: 30 },
+        whenHandedOver: "2021-01-01",
+      }),
+      build("MedicationDispense", {
+        status: "completed",
+        daysSupply: { value: 30 },
+        whenHandedOver: "2021-01-15",
+      }),
+      build("MedicationDispense", {
+        status: "completed",
+        daysSupply: { value: 90 },
+        whenHandedOver: "2021-01-01",
+      }),
+      build("MedicationDispense", {
+        status: "completed",
+        daysSupply: { value: 15 },
+        whenHandedOver: "2021-03-01",
+      }),
+    ];
+    const result = buildTimelineOfResourcesWithPeriods({
+      resources,
+      periodFn: medicationDispensePeriodFn,
+    });
+
+    expect(result).toMatchObject(<Timeline<MedicationDispense>>{
+      blocks: [
+        {
+          period: {
+            start: "2021-01-01",
+            end: "2021-01-15",
+          },
+          items: [resources[0], resources[2]],
+        },
+        {
+          period: {
+            start: "2021-01-15",
+            end: "2021-01-31",
+          },
+          items: [resources[0], resources[1], resources[2]],
+        },
+        {
+          period: {
+            start: "2021-01-31",
+            end: "2021-02-14",
+          },
+          items: [resources[1], resources[2]],
+        },
+        {
+          period: {
+            start: "2021-02-14",
+            end: "2021-03-01",
+          },
+          items: [resources[2]],
+        },
+        {
+          period: {
+            start: "2021-03-01",
+            end: "2021-03-16",
+          },
+          items: [resources[2], resources[3]],
+        },
+        {
+          period: {
+            start: "2021-03-16",
+            end: "2021-04-01",
+          },
+          items: [resources[2]],
+        },
+      ],
+    });
+  });
+});
+
+function medicationDispensePeriodFn(
+  resource: MedicationDispense
+): WithRequired<Period, "start" | "end"> {
+  return {
+    start: resource.whenHandedOver!,
+    end: addDays(
+      new Date(resource.whenHandedOver!),
+      resource.daysSupply!.value!
+    )
+      .toISOString()
+      .slice(0, 10),
+  };
+}

--- a/packages/core/r4b/period-calculator.ts
+++ b/packages/core/r4b/period-calculator.ts
@@ -1,0 +1,131 @@
+import { Period } from "fhir/r4";
+import _ from "lodash";
+import { WithRequired } from "./types";
+
+export interface Timeline<T> {
+  /**
+   * Discrete blocks of different periods
+   */
+  blocks: TimelineBlock<T>[];
+}
+
+export interface TimelineBlock<T> {
+  /**
+   * The start / end for that block.
+   */
+  period: WithRequired<Period, "start" | "end">;
+
+  /**
+   * The items that are included in that period.
+   * An item may appear in multiple blocks.
+   */
+  items: T[];
+}
+
+export interface BuildTimelineOfResourcesWithPeriodsArgs<T> {
+  /**
+   * The resources to place into different blocks
+   */
+  resources: T[];
+
+  /**
+   * The method to extract a `Period` from a resource.
+   */
+  periodFn: (resource: T) => WithRequired<Period, "start" | "end">;
+}
+
+/**
+ * From a list of resources that can be associated with a period, compute a timeline of multiple
+ * blocks where resources are placed.
+ * One of the advantage is to see if there was overlap, and for how many periods.
+ *
+ * @example:
+ * const resources = [
+ *    build("MedicationDispense", {
+ *        status: "completed",
+ *        daysSupply: { value: 30 },
+ *        whenHandedOver: "2021-01-01",
+ *      }),
+ *      build("MedicationDispense", {
+ *        status: "completed",
+ *        daysSupply: { value: 30 },
+ *        whenHandedOver: "2021-01-15",
+ *      }),
+ *    ];
+ *    const result = buildTimelineOfResourcesWithPeriods({
+ *      resources,
+ *      periodFn: (resource) => ({
+ *        start: resource.whenHandedOver!,
+ *        end: addDays(
+ *          new Date(resource.whenHandedOver!),
+ *          resource.daysSupply!.value!
+ *        )
+ *          .toISOString()
+ *          .slice(0, 10),
+ *      }),
+ *    });
+ *
+ *    > {
+ *      blocks: [
+ *        {
+ *          period: {
+ *            start: "2021-01-01",
+ *            end: "2021-01-15",
+ *          },
+ *          items: [resources[0]],
+ *        },
+ *        {
+ *          period: {
+ *            start: "2021-01-15",
+ *            end: "2021-01-31",
+ *          },
+ *          items: [resources[0], resources[1]],
+ *        },
+ *        {
+ *          period: {
+ *            start: "2021-01-31",
+ *            end: "2021-02-14",
+ *          },
+ *          items: [resources[1]],
+ *        },
+ *      ],
+ *    }
+ *
+ */
+export function buildTimelineOfResourcesWithPeriods<T>({
+  resources,
+  periodFn,
+}: BuildTimelineOfResourcesWithPeriodsArgs<T>): Timeline<T> {
+  const tuples: Array<[T, WithRequired<Period, "start" | "end">]> =
+    resources.map((resource) => [resource, periodFn(resource)]);
+
+  const ticks = _(tuples)
+    .flatMap((tuple) => [tuple[1].start, tuple[1].end])
+    .uniq()
+    .sort()
+    .value();
+
+  const blocks: TimelineBlock<T>[] = [];
+
+  for (let i = 0; i < ticks.length - 1; i++) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const start = ticks[i]!;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const end = ticks[i + 1]!;
+
+    blocks.push({
+      period: {
+        start,
+        end,
+      },
+      items: _(tuples)
+        .filter(([, period]) => start < period.end && end > period.start)
+        .map(([resource]) => resource)
+        .value(),
+    });
+  }
+
+  return {
+    blocks: blocks.filter((block) => block.items.length),
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1761,6 +1761,7 @@ __metadata:
     "@types/fhir": ^0.0.35
     "@types/node": ^18.11.18
     "@types/rimraf": ^3
+    date-fns: ^2.29.3
     eslint: ^8.30.0
     fhirpath: ^3.3.1
     html-entities: ^2.3.3
@@ -8494,6 +8495,13 @@ __metadata:
   version: 1.30.1
   resolution: "date-fns@npm:1.30.1"
   checksum: 86b1f3269cbb1f3ee5ac9959775ea6600436f4ee2b78430cd427b41a0c9fabf740b1a5d401c085f3003539a6f4755c7c56c19fbd70ce11f6f673f6bc8075b710
+  languageName: node
+  linkType: hard
+
+"date-fns@npm:^2.29.3":
+  version: 2.29.3
+  resolution: "date-fns@npm:2.29.3"
+  checksum: e01cf5b62af04e05dfff921bb9c9933310ed0e1ae9a81eb8653452e64dc841acf7f6e01e1a5ae5644d0337e9a7f936175fd2cb6819dc122fdd9c5e86c56be484
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What is this about

This PR adds a method `buildTimelineOfResourcesWithPeriods` to `core` that can compute a timeline using a series of `Period`.

## Issue ticket numbers

N/A

## How can this be tested?

Automated tests included.

## Known limitations/edge cases

N/A