### PR TITLE
feat: add bundleResources helper method to bundle navigator

### DIFF
--- a/packages/core/r4b/bundle-navigator.test.ts
+++ b/packages/core/r4b/bundle-navigator.test.ts
@@ -281,4 +281,22 @@ describe("BundleNavigator", () => {
       );
     });
   });
+
+  describe("resources", () => {
+    it("returns all the resources", () => {
+      const navigator = bundleNavigator<Patient, Provenance | Organization>(
+        patientsListBundle
+      );
+
+      expect([...navigator.resources]).toHaveLength(102);
+    });
+
+    describe("for an empty bundle", () => {
+      it("returns an empty array", () => {
+        const navigator = bundleNavigator(emptyBundle);
+
+        expect([...navigator.resources]).toStrictEqual([]);
+      });
+    });
+  });
 });

--- a/packages/core/r4b/bundle-navigator.ts
+++ b/packages/core/r4b/bundle-navigator.ts
@@ -65,7 +65,7 @@ export class BundleNavigator<
     | undefined;
 
   // Index resources first by a fhirPath indicating a reverse reference
-  // (probably obtain through a revinclude instruction), then by the actual reverse reference - e.g.
+  // (probably obtained through a _revinclude instruction), then by the actual reverse reference - e.g.
   // "ofType(Provenance).target.reference" -> Patient/982effa0-aa0f-4995-b380-c1621b1f0ffc -> [Provenance]
   // Built by _ensureFhirPathIndex
   private _resourcesByRefFhirPathIndex:
@@ -218,11 +218,23 @@ export class BundleNavigator<
     >[];
   }
 
+  /**
+   * Return all unique resources across bundles.
+   **/
+  public get resources(): IterableIterator<
+    PrimaryResourceType | SecondaryResourceType
+  > {
+    this._ensurePrimaryIndices();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return this._resourcesByRelativeReference!.values();
+  }
+
   private _ensurePrimaryIndices() {
     if (!this._resourcesByRelativeReference) {
       this._resourcesByRelativeReference = new Map();
       this._resourcesBySearchMode = new Map();
       this._resourcesByType = new Map();
+
       for (const entry of this._bundles
         .flatMap(
           (x) =>


### PR DESCRIPTION
## What is this about

Add a new helper to grab all the resources of a bundler at once

## Issue ticket numbers

#48 

## How can this be tested?

Not sure

## Known limitations/edge cases

- Unsorted array
- should we push the resource to the array only if the resource has an id?
