### PR TITLE
fix(fhir-query): :green_heart: fix CI build tests

### DIFF
--- a/packages/fhir-query/package.json
+++ b/packages/fhir-query/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "yarn clean && tsc --project tsconfig.build.json",
-    "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
+    "check": "prettier --check ./**/*.tsx && eslint ./**/*.tsx && tsc --noEmit",
     "clean": "rimraf dist/",
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish",

--- a/packages/fhir-query/tsconfig.build.json
+++ b/packages/fhir-query/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["**/*.test.ts", "**/__fixtures__"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/__fixtures__"],
   "compilerOptions": {
     "outDir": "dist"
   }


### PR DESCRIPTION
## What is this about

This PR fixes the CI main Build when running `fhir-query` tests.
The issue is that the tests where included in the build undle, instead of being properly excluded.

## Issue ticket numbers

See https://github.com/bonfhir/bonfhir/actions/runs/4104656697/jobs/7080429325

## How can this be tested?

Run `yarn build` and then `yarn test`

## Known limitations/edge cases

N/A
