### PR TITLE
Introduce data adapters

### DIFF
--- a/packages/core/r4b/data-type-adapter.test.ts
+++ b/packages/core/r4b/data-type-adapter.test.ts
@@ -1,57 +1,21 @@
-import {
-  DateStyle,
-  FhirDate,
-  intlFhirDataTypeAdapter,
-} from "./data-type-adapter";
+import { intlFhirDataTypeAdapter } from "./data-type-adapter";
 
 describe("intlFhirDataTypeAdapter", () => {
-  const adapter = intlFhirDataTypeAdapter("en-us");
+  ["en-us", undefined, "fr-CA"].forEach((locale) => {
+    describe(`with ${locale} as locale`, () => {
+      const adapter = intlFhirDataTypeAdapter(locale);
 
-  describe("date", () => {
-    it.each(<Array<[string, Partial<FhirDate>]>>[
-      [
-        "2023-01-01",
-        {
-          date: new Date(2023, 0, 1),
-          flavour: "full",
-          year: 2023,
-          month: 1,
-          day: 1,
-        },
-      ],
-      [
-        "2023-02",
-        {
-          date: new Date(2023, 1, 1),
-          flavour: "year-month",
-          year: 2023,
-          month: 2,
-          day: undefined,
-        },
-      ],
-      [
-        "2020",
-        {
-          date: new Date(2020, 0, 1),
-          flavour: "year",
-          year: 2020,
-          month: undefined,
-          day: undefined,
-        },
-      ],
-    ])("parse %p", (value, expected) => {
-      expect(adapter.date.parse(value)).toMatchObject(expected);
+      it("exposes different adapters", () => {
+        expect(typeof adapter.date.format).toBe("function");
+      });
     });
+  });
 
-    it.each(<Array<[string | FhirDate, DateStyle | undefined, string]>>[
-      ["2023-02-08", undefined, "2/8/2023"],
-      ["2023-02-08", "full", "Wednesday, February 8, 2023"],
-      ["2023-02-08", "medium", "Feb 8, 2023"],
-      ["2023-02-08", "short", "2/8/23"],
-      ["2023-02", "medium", "Feb 2023"],
-      ["2023", undefined, "2023"],
-    ])("format %p", (value, style, expected) => {
-      expect(adapter.date.format(value, style)).toEqual(expected);
+  describe("with an unknown locale", () => {
+    it("raises an error", () => {
+      expect(() => intlFhirDataTypeAdapter("nope")).toThrowError(
+        "Incorrect locale information provided"
+      );
     });
   });
 });

--- a/packages/core/r4b/data-type-adapter.test.ts
+++ b/packages/core/r4b/data-type-adapter.test.ts
@@ -1,0 +1,57 @@
+import {
+  DateStyle,
+  FhirDate,
+  intlFhirDataTypeAdapter,
+} from "./data-type-adapter";
+
+describe("intlFhirDataTypeAdapter", () => {
+  const adapter = intlFhirDataTypeAdapter("en-us");
+
+  describe("date", () => {
+    it.each(<Array<[string, Partial<FhirDate>]>>[
+      [
+        "2023-01-01",
+        {
+          date: new Date(2023, 0, 1),
+          flavour: "full",
+          year: 2023,
+          month: 1,
+          day: 1,
+        },
+      ],
+      [
+        "2023-02",
+        {
+          date: new Date(2023, 1, 1),
+          flavour: "year-month",
+          year: 2023,
+          month: 2,
+          day: undefined,
+        },
+      ],
+      [
+        "2020",
+        {
+          date: new Date(2020, 0, 1),
+          flavour: "year",
+          year: 2020,
+          month: undefined,
+          day: undefined,
+        },
+      ],
+    ])("parse %p", (value, expected) => {
+      expect(adapter.date.parse(value)).toMatchObject(expected);
+    });
+
+    it.each(<Array<[string | FhirDate, DateStyle | undefined, string]>>[
+      ["2023-02-08", undefined, "2/8/2023"],
+      ["2023-02-08", "full", "Wednesday, February 8, 2023"],
+      ["2023-02-08", "medium", "Feb 8, 2023"],
+      ["2023-02-08", "short", "2/8/23"],
+      ["2023-02", "medium", "Feb 2023"],
+      ["2023", undefined, "2023"],
+    ])("format %p", (value, style, expected) => {
+      expect(adapter.date.format(value, style)).toEqual(expected);
+    });
+  });
+});

--- a/packages/core/r4b/data-type-adapter.ts
+++ b/packages/core/r4b/data-type-adapter.ts
@@ -1,0 +1,152 @@
+/**
+ * This is used to manipulate FHIR data types, both parsing values and formatting them as localized strings.
+ *
+ * @see https://hl7.org/fhir/datatypes.html
+ */
+export interface FhirDataTypeAdapter {
+  /**
+   * A date, or partial date (e.g. just year or year + month) as used in human communication.
+   *
+   * @see https://hl7.org/fhir/datatypes.html#date
+   */
+  date: {
+    /**
+     * Parse a FHIR date
+     *
+     * @see https://hl7.org/fhir/datatypes.html
+     */
+    parse(value: null | undefined): undefined;
+    parse(value: string): FhirDate;
+    parse(value: string | null | undefined): FhirDate | undefined;
+
+    format(
+      value: FhirDate | string | null | undefined,
+      style?: DateStyle | null | undefined
+    ): string;
+  };
+}
+
+export type DateStyle = "full" | "long" | "medium" | "short";
+
+/**
+ * A parsed FHIR date
+ *
+ * @see https://hl7.org/fhir/datatypes.html#date
+ */
+export interface FhirDate {
+  /**
+   * The date as a Javascript Date. Only the date portion is significant, you must ignore the time.
+   * May be inaccurate if the original value was missing day or month information.
+   */
+  date: Date;
+
+  /**
+   * The original flavour - indicates if it only had year, year-month, or was a complete date.
+   */
+  flavour: "year" | "year-month" | "full";
+
+  year: number;
+
+  /**
+   * The month number, **starting at 1**
+   * Be careful, as the Javascript Date object starts month at 0 :-(.
+   */
+  month: number | undefined;
+
+  /**
+   * The day number, **starting at 1**
+   */
+  day: number | undefined;
+}
+
+const fhirDateRegexp = new RegExp(
+  "^(?<year>[0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)" +
+    "(-(?<month>0[1-9]|1[0-2])" +
+    "(-(?<day>0[1-9]|[1-2][0-9]|3[0-1]))?)?$"
+);
+
+/**
+ * Return a {@link FhirDataTypeAdapter} that uses the [`Intl` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl)
+ * (ECMAScript Internationalization API)
+ * @param locale - see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument
+ */
+export function intlFhirDataTypeAdapter(
+  locale: string | undefined
+): FhirDataTypeAdapter {
+  return {
+    date: {
+      parse(value) {
+        if (!value?.trim()) {
+          return undefined;
+        }
+
+        const matchingData = value.trim().match(fhirDateRegexp)?.groups;
+        if (!matchingData?.year)
+          throw new Error(
+            "Value does not match the fhir date format as described in `https://hl7.org/fhir/datatypes.html#date'"
+          );
+
+        const { year, month, day } = matchingData;
+        const yearNumber = parseInt(year);
+        const monthNumber = month ? parseInt(month) : undefined;
+        const dayNumber = day ? parseInt(day) : undefined;
+
+        return {
+          date: new Date(
+            yearNumber,
+            monthNumber ? monthNumber - 1 : 0,
+            dayNumber || 1
+          ),
+          flavour: day ? "full" : month ? "year-month" : "year",
+          year: yearNumber,
+          month: monthNumber,
+          day: dayNumber,
+          // This feels like a bug in TypeScript
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+      },
+
+      format(value, style) {
+        if (!value) {
+          return "";
+        }
+
+        const fhirDate = typeof value === "string" ? this.parse(value) : value;
+
+        switch (fhirDate.flavour) {
+          case "year":
+            return new Intl.DateTimeFormat(locale, { year: "numeric" }).format(
+              fhirDate.date
+            );
+          case "year-month":
+            return new Intl.DateTimeFormat(locale, {
+              year: "numeric",
+              month: convertDateStyleToMonthStyle(style),
+            }).format(fhirDate.date);
+          case "full":
+            return new Intl.DateTimeFormat(locale, {
+              dateStyle: style || undefined,
+            }).format(fhirDate.date);
+          default:
+            throw new Error(`Unknown date flavour ${fhirDate.flavour}`);
+        }
+      },
+    },
+  };
+}
+
+function convertDateStyleToMonthStyle(
+  style: DateStyle | null | undefined
+): "numeric" | "2-digit" | "long" | "short" | "narrow" | undefined {
+  switch (style) {
+    case "full":
+    case "long":
+      return "long";
+    case "medium":
+      return "short";
+    case "short":
+      return "2-digit";
+    default:
+      return undefined;
+  }
+}

--- a/packages/core/r4b/data-type-adapter.ts
+++ b/packages/core/r4b/data-type-adapter.ts
@@ -1,69 +1,14 @@
+import { FhirDateTypeAdapter, fhirDateTypeAdapter } from "./data-types/date";
+
 /**
  * This is used to manipulate FHIR data types, both parsing values and formatting them as localized strings.
  *
  * @see https://hl7.org/fhir/datatypes.html
  */
 export interface FhirDataTypeAdapter {
-  /**
-   * A date, or partial date (e.g. just year or year + month) as used in human communication.
-   *
-   * @see https://hl7.org/fhir/datatypes.html#date
-   */
-  date: {
-    /**
-     * Parse a FHIR date
-     *
-     * @see https://hl7.org/fhir/datatypes.html
-     */
-    parse(value: null | undefined): undefined;
-    parse(value: string): FhirDate;
-    parse(value: string | null | undefined): FhirDate | undefined;
-
-    format(
-      value: FhirDate | string | null | undefined,
-      style?: DateStyle | null | undefined
-    ): string;
-  };
+  locale: string | undefined;
+  date: FhirDateTypeAdapter;
 }
-
-export type DateStyle = "full" | "long" | "medium" | "short";
-
-/**
- * A parsed FHIR date
- *
- * @see https://hl7.org/fhir/datatypes.html#date
- */
-export interface FhirDate {
-  /**
-   * The date as a Javascript Date. Only the date portion is significant, you must ignore the time.
-   * May be inaccurate if the original value was missing day or month information.
-   */
-  date: Date;
-
-  /**
-   * The original flavour - indicates if it only had year, year-month, or was a complete date.
-   */
-  flavour: "year" | "year-month" | "full";
-
-  year: number;
-
-  /**
-   * The month number, **starting at 1**
-   * Be careful, as the Javascript Date object starts month at 0 :-(.
-   */
-  month: number | undefined;
-
-  /**
-   * The day number, **starting at 1**
-   */
-  day: number | undefined;
-}
-
-const fhirDateRegexp = new RegExp(
-  "^(?<year>[0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)" +
-    "(-(?<month>0[1-9]|1[0-2])" +
-    "(-(?<day>0[1-9]|[1-2][0-9]|3[0-1]))?)?$"
-);
 
 /**
  * Return a {@link FhirDataTypeAdapter} that uses the [`Intl` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl)
@@ -73,80 +18,13 @@ const fhirDateRegexp = new RegExp(
 export function intlFhirDataTypeAdapter(
   locale: string | undefined
 ): FhirDataTypeAdapter {
+  // JIT locale check
+  Intl.DateTimeFormat(locale);
+
   return {
-    date: {
-      parse(value) {
-        if (!value?.trim()) {
-          return undefined;
-        }
-
-        const matchingData = value.trim().match(fhirDateRegexp)?.groups;
-        if (!matchingData?.year)
-          throw new Error(
-            "Value does not match the fhir date format as described in `https://hl7.org/fhir/datatypes.html#date'"
-          );
-
-        const { year, month, day } = matchingData;
-        const yearNumber = parseInt(year);
-        const monthNumber = month ? parseInt(month) : undefined;
-        const dayNumber = day ? parseInt(day) : undefined;
-
-        return {
-          date: new Date(
-            yearNumber,
-            monthNumber ? monthNumber - 1 : 0,
-            dayNumber || 1
-          ),
-          flavour: day ? "full" : month ? "year-month" : "year",
-          year: yearNumber,
-          month: monthNumber,
-          day: dayNumber,
-          // This feels like a bug in TypeScript
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } as any;
-      },
-
-      format(value, style) {
-        if (!value) {
-          return "";
-        }
-
-        const fhirDate = typeof value === "string" ? this.parse(value) : value;
-
-        switch (fhirDate.flavour) {
-          case "year":
-            return new Intl.DateTimeFormat(locale, { year: "numeric" }).format(
-              fhirDate.date
-            );
-          case "year-month":
-            return new Intl.DateTimeFormat(locale, {
-              year: "numeric",
-              month: convertDateStyleToMonthStyle(style),
-            }).format(fhirDate.date);
-          case "full":
-            return new Intl.DateTimeFormat(locale, {
-              dateStyle: style || undefined,
-            }).format(fhirDate.date);
-          default:
-            throw new Error(`Unknown date flavour ${fhirDate.flavour}`);
-        }
-      },
-    },
+    locale: locale,
+    date: fhirDateTypeAdapter(locale),
   };
 }
 
-function convertDateStyleToMonthStyle(
-  style: DateStyle | null | undefined
-): "numeric" | "2-digit" | "long" | "short" | "narrow" | undefined {
-  switch (style) {
-    case "full":
-    case "long":
-      return "long";
-    case "medium":
-      return "short";
-    case "short":
-      return "2-digit";
-    default:
-      return undefined;
-  }
-}
+export * from "./data-types/date";

--- a/packages/core/r4b/data-types/date.test.ts
+++ b/packages/core/r4b/data-types/date.test.ts
@@ -1,0 +1,74 @@
+import { DateStyle, FhirDate, fhirDateTypeAdapter } from "./date";
+
+describe("fhirDateTypeAdapter", () => {
+  ["en-us", undefined].forEach((locale) => {
+    describe(`with ${locale} as locale`, () => {
+      const adapter = fhirDateTypeAdapter(locale);
+
+      describe("date", () => {
+        it.each(<Array<[string, Partial<FhirDate>]>>[
+          [
+            "2023-01-01",
+            {
+              date: new Date(2023, 0, 1),
+              flavour: "full",
+              year: 2023,
+              month: 1,
+              day: 1,
+            },
+          ],
+          [
+            "2023-02",
+            {
+              date: new Date(2023, 1, 1),
+              flavour: "year-month",
+              year: 2023,
+              month: 2,
+              day: undefined,
+            },
+          ],
+          [
+            "2020",
+            {
+              date: new Date(2020, 0, 1),
+              flavour: "year",
+              year: 2020,
+              month: undefined,
+              day: undefined,
+            },
+          ],
+        ])("parse %p", (value, expected) => {
+          expect(adapter.parse(value)).toMatchObject(expected);
+        });
+
+        it.each(<Array<[string | FhirDate, DateStyle | undefined, string]>>[
+          ["2023-02-08", undefined, "2/8/2023"],
+          ["2023-02-08", "full", "Wednesday, February 8, 2023"],
+          ["2023-02-08", "medium", "Feb 8, 2023"],
+          ["2023-02-08", "short", "2/8/23"],
+          ["2023-02", "medium", "Feb 2023"],
+          ["2023", undefined, "2023"],
+        ])("format %p", (value, style, expected) => {
+          expect(adapter.format(value, style)).toEqual(expected);
+        });
+      });
+    });
+  });
+
+  describe("with french locale", () => {
+    const adapter = fhirDateTypeAdapter("fr-CA");
+
+    describe("date", () => {
+      it.each(<Array<[string | FhirDate, DateStyle | undefined, string]>>[
+        ["2023-02-08", undefined, "2023-02-08"],
+        ["2023-02-08", "full", "mercredi 8 février 2023"],
+        ["2023-02-08", "medium", "8 févr. 2023"],
+        ["2023-02-08", "short", "2023-02-08"],
+        ["2023-02", "medium", "févr. 2023"],
+        ["2023", undefined, "2023"],
+      ])("format %p", (value, style, expected) => {
+        expect(adapter.format(value, style)).toEqual(expected);
+      });
+    });
+  });
+});

--- a/packages/core/r4b/data-types/date.ts
+++ b/packages/core/r4b/data-types/date.ts
@@ -1,0 +1,143 @@
+/**
+ * A date, or partial date (e.g. just year or year + month) as used in human communication.
+ *
+ * @see https://hl7.org/fhir/datatypes.html#date
+ */
+
+export interface FhirDateTypeAdapter {
+  /**
+   * Parse a FHIR date
+   *
+   * @see https://hl7.org/fhir/datatypes.html
+   */
+  parse(value: string | null | undefined): FhirDate | undefined;
+
+  /**
+   * Format a FHIR date
+   *
+   * @see https://hl7.org/fhir/datatypes.html
+   */
+  format(
+    value: FhirDate | string | null | undefined,
+    style?: DateStyle | null | undefined
+  ): string;
+}
+
+export type DateStyle = "full" | "long" | "medium" | "short";
+
+/**
+ * A parsed FHIR date
+ *
+ * @see https://hl7.org/fhir/datatypes.html#date
+ */
+export interface FhirDate {
+  /**
+   * The date as a Javascript Date. Only the date portion is significant, you must ignore the time.
+   * May be inaccurate if the original value was missing day or month information.
+   */
+  date: Date;
+
+  /**
+   * The original flavour - indicates if it only had year, year-month, or was a complete date.
+   */
+  flavour: "year" | "year-month" | "full";
+
+  year: number;
+
+  /**
+   * The month number, **starting at 1**
+   * Be careful, as the Javascript Date object starts month at 0 :-(.
+   */
+  month: number | undefined;
+
+  /**
+   * The day number, **starting at 1**
+   */
+  day: number | undefined;
+}
+
+const fhirDateRegexp = new RegExp(
+  "^(?<year>[0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)" +
+    "(-(?<month>0[1-9]|1[0-2])" +
+    "(-(?<day>0[1-9]|[1-2][0-9]|3[0-1]))?)?$"
+);
+
+/**
+ * Return a {@link FhirDataTypeAdapter} that uses the [`Intl` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl)
+ * (ECMAScript Internationalization API)
+ * @param locale - see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument
+ */
+export function fhirDateTypeAdapter(
+  locale: string | undefined
+): FhirDateTypeAdapter {
+  return {
+    parse(value) {
+      if (!value?.trim()) {
+        return undefined;
+      }
+
+      const matchingData = value.trim().match(fhirDateRegexp)?.groups;
+      if (!matchingData?.year)
+        throw new Error(
+          "Value does not match the fhir date format as described in `https://hl7.org/fhir/datatypes.html#date'"
+        );
+
+      const { year, month, day } = matchingData;
+      const yearNumber = parseInt(year);
+      const monthNumber = month ? parseInt(month) : undefined;
+      const dayNumber = day ? parseInt(day) : undefined;
+
+      return {
+        date: new Date(
+          yearNumber,
+          monthNumber ? monthNumber - 1 : 0,
+          dayNumber || 1
+        ),
+        flavour: day ? "full" : month ? "year-month" : "year",
+        year: yearNumber,
+        month: monthNumber,
+        day: dayNumber,
+      };
+    },
+
+    format(value, style) {
+      const fhirDate = typeof value === "string" ? this.parse(value) : value;
+
+      if (!fhirDate) return "";
+
+      switch (fhirDate.flavour) {
+        case "year":
+          return new Intl.DateTimeFormat(locale, { year: "numeric" }).format(
+            fhirDate.date
+          );
+        case "year-month":
+          return new Intl.DateTimeFormat(locale, {
+            year: "numeric",
+            month: convertDateStyleToMonthStyle(style),
+          }).format(fhirDate.date);
+        case "full":
+          return new Intl.DateTimeFormat(locale, {
+            dateStyle: style || undefined,
+          }).format(fhirDate.date);
+        default:
+          throw new Error(`Unknown date flavour ${fhirDate.flavour}`);
+      }
+    },
+  };
+}
+
+function convertDateStyleToMonthStyle(
+  style: DateStyle | null | undefined
+): "numeric" | "2-digit" | "long" | "short" | "narrow" | undefined {
+  switch (style) {
+    case "full":
+    case "long":
+      return "long";
+    case "medium":
+      return "short";
+    case "short":
+      return "2-digit";
+    default:
+      return undefined;
+  }
+}

--- a/packages/core/r4b/index.ts
+++ b/packages/core/r4b/index.ts
@@ -1,5 +1,6 @@
 export * from "./builders";
 export * from "./bundle-navigator";
+export * from "./data-type-adapter";
 export * from "./date";
 export * from "./fhir-restful-client";
 export * from "./merge";

--- a/packages/terminology/package.json
+++ b/packages/terminology/package.json
@@ -11,8 +11,7 @@
     "clean": "rimraf dist/",
     "codegen": "yarn workspace @bonfhir/codegen run dev run -d \"${PWD}/../../fhir/r4b/**/*.json\" -t \"${PWD}/r4b/**/*.ts.hbs\" --helpers \"${PWD}/template-helpers.js\" -p 'prettier --write %files%'",
     "package:create": "node package.js pack",
-    "package:publish": "node package.js publish",
-    "test": "jest"
+    "package:publish": "node package.js publish"
   },
   "packageManager": "yarn@3.3.1",
   "devDependencies": {


### PR DESCRIPTION
## What is this about

Introduce data adapter
Data adapters are meant to parse FHIR data types into usable objects, and to then format it (for example with specific locale or format)

## Issue ticket numbers

https://github.com/bonfhir/bonfhir/issues/63