### PR TITLE
fix(core): :bug: add `patient` and `code` to `resourceSearch("Condition")`

### DIFF
--- a/fhir/r4b/definitions/search-parameters.json
+++ b/fhir/r4b/definitions/search-parameters.json
@@ -18633,6 +18633,51 @@
       }
     },
     {
+      "fullUrl": "http://hl7.org/fhir/SearchParameter/Condition-code",
+      "resource": {
+        "resourceType": "SearchParameter",
+        "id": "Condition-code",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+            "valueCode": "trial-use"
+          }
+        ],
+        "url": "http://hl7.org/fhir/SearchParameter/Condition-code",
+        "version": "4.3.0",
+        "name": "code",
+        "status": "draft",
+        "experimental": false,
+        "date": "2022-05-28T12:47:40+10:00",
+        "publisher": "Health Level Seven International (Patient Care)",
+        "contact": [
+          {
+            "telecom": [
+              {
+                "system": "url",
+                "value": "http://hl7.org/fhir"
+              }
+            ]
+          },
+          {
+            "telecom": [
+              {
+                "system": "url",
+                "value": "http://www.hl7.org/Special/committees/patientcare/index.cfm"
+              }
+            ]
+          }
+        ],
+        "description": "Code for the condition",
+        "code": "code",
+        "base": ["Condition"],
+        "type": "token",
+        "expression": "Condition.code",
+        "xpath": "f:Condition/f:code",
+        "xpathUsage": "normal"
+      }
+    },
+    {
       "fullUrl": "http://hl7.org/fhir/SearchParameter/Condition-encounter",
       "resource": {
         "resourceType": "SearchParameter",
@@ -19045,6 +19090,52 @@
         "expression": "Condition.onset.as(string)",
         "xpath": "f:Condition/f:onsetString",
         "xpathUsage": "normal"
+      }
+    },
+    {
+      "fullUrl": "http://hl7.org/fhir/SearchParameter/Condition-patient",
+      "resource": {
+        "resourceType": "SearchParameter",
+        "id": "Condition-patient",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+            "valueCode": "trial-use"
+          }
+        ],
+        "url": "http://hl7.org/fhir/SearchParameter/Condition-patient",
+        "version": "4.3.0",
+        "name": "patient",
+        "status": "draft",
+        "experimental": false,
+        "date": "2022-05-28T12:47:40+10:00",
+        "publisher": "Health Level Seven International (Patient Care)",
+        "contact": [
+          {
+            "telecom": [
+              {
+                "system": "url",
+                "value": "http://hl7.org/fhir"
+              }
+            ]
+          },
+          {
+            "telecom": [
+              {
+                "system": "url",
+                "value": "http://www.hl7.org/Special/committees/patientcare/index.cfm"
+              }
+            ]
+          }
+        ],
+        "description": "Who has the condition?",
+        "code": "patient",
+        "base": ["Condition"],
+        "type": "reference",
+        "expression": "Condition.subject.where(resolve() is Patient)",
+        "xpath": "f:Condition/f:subject",
+        "xpathUsage": "normal",
+        "target": ["Patient"]
       }
     },
     {

--- a/packages/core/r4b/resource-search.ts
+++ b/packages/core/r4b/resource-search.ts
@@ -19295,6 +19295,33 @@ class ResourceSearchBuilderCondition {
   }
 
   /**
+   * Code for the condition
+   */
+  code(
+    value:
+      | {
+          system?: string | null | undefined;
+          code?: string | null | undefined;
+          value?: string | null | undefined;
+        }
+      | string
+      | Array<
+          | {
+              system?: string | null | undefined;
+              code?: string | null | undefined;
+              value?: string | null | undefined;
+            }
+          | string
+        >
+      | null
+      | undefined,
+    modifier?: TokenModifier | null | undefined
+  ): ResourceSearchBuilderCondition {
+    this.builder.token("code", value, modifier);
+    return this;
+  }
+
+  /**
    * Encounter created as part of
    */
   encounter(
@@ -19427,6 +19454,35 @@ class ResourceSearchBuilderCondition {
     modifier?: StringModifier | null | undefined
   ): ResourceSearchBuilderCondition {
     this.builder.string("onset-info", value, modifier);
+    return this;
+  }
+
+  /**
+   * Who has the condition?
+   */
+  patient(
+    id:
+      | { id: string; type: string }
+      | {
+          system?: string | null | undefined;
+          code?: string | null | undefined;
+          value?: string | null | undefined;
+        }
+      | string
+      | Array<
+          | { id: string; type: string }
+          | {
+              system?: string | null | undefined;
+              code?: string | null | undefined;
+              value?: string | null | undefined;
+            }
+          | string
+        >
+      | null
+      | undefined,
+    modifier?: ":identifier" | ResourceType | null | undefined
+  ): ResourceSearchBuilderCondition {
+    this.builder.reference("patient", id, modifier);
     return this;
   }
 
@@ -19593,6 +19649,8 @@ export type SortOrderCondition =
   | "-category"
   | "clinical-status"
   | "-clinical-status"
+  | "code"
+  | "-code"
   | "encounter"
   | "-encounter"
   | "evidence"
@@ -19605,6 +19663,8 @@ export type SortOrderCondition =
   | "-onset-date"
   | "onset-info"
   | "-onset-info"
+  | "patient"
+  | "-patient"
   | "recorded-date"
   | "-recorded-date"
   | "severity"


### PR DESCRIPTION
## What is this about

add `patient` and `code` to `resourceSearch("Condition")`.
They were missing from the FHIR definition files.

## Issue ticket numbers

Fix #79

## How can this be tested?

N/A

## Known limitations/edge cases

N/A