### PR TITLE
feat(core): support for uri, url and canonical primitive types

### DIFF
--- a/packages/core/r4b/data-type-adapter.test.ts
+++ b/packages/core/r4b/data-type-adapter.test.ts
@@ -7,6 +7,9 @@ describe("intlFhirDataTypeAdapter", () => {
 
       it("exposes different adapters", () => {
         expect(typeof adapter.date.format).toBe("function");
+        expect(typeof adapter.uri.format).toBe("function");
+        expect(typeof adapter.uri.format).toBe("function");
+        expect(typeof adapter.canonical.format).toBe("function");
         expect(typeof adapter.integer.format).toBe("function");
         expect(typeof adapter.decimal.format).toBe("function");
       });

--- a/packages/core/r4b/data-type-adapter.ts
+++ b/packages/core/r4b/data-type-adapter.ts
@@ -1,3 +1,7 @@
+import {
+  FhirCanonicalTypeAdapter,
+  fhirCanonicalTypeAdapter,
+} from "./data-types/canonical";
 import { FhirDateTypeAdapter, fhirDateTypeAdapter } from "./data-types/date";
 import {
   FhirDecimalTypeAdapter,
@@ -7,6 +11,8 @@ import {
   FhirIntegerTypeAdapter,
   fhirIntegerTypeAdapter,
 } from "./data-types/integer";
+import { FhirURITypeAdapter, fhirURITypeAdapter } from "./data-types/URI";
+import { FhirURLTypeAdapter, fhirURLTypeAdapter } from "./data-types/URL";
 
 /**
  * This is used to manipulate FHIR data types, both parsing values and formatting them as localized strings.
@@ -18,6 +24,9 @@ export interface FhirDataTypeAdapter {
   date: FhirDateTypeAdapter;
   integer: FhirIntegerTypeAdapter;
   decimal: FhirDecimalTypeAdapter;
+  uri: FhirURITypeAdapter;
+  url: FhirURLTypeAdapter;
+  canonical: FhirCanonicalTypeAdapter;
 }
 
 /**
@@ -36,6 +45,9 @@ export function intlFhirDataTypeAdapter(
     date: fhirDateTypeAdapter(locale),
     integer: fhirIntegerTypeAdapter(locale),
     decimal: fhirDecimalTypeAdapter(locale),
+    uri: fhirURITypeAdapter(locale),
+    url: fhirURLTypeAdapter(locale),
+    canonical: fhirCanonicalTypeAdapter(locale),
   };
 }
 

--- a/packages/core/r4b/data-types/URI.test.ts
+++ b/packages/core/r4b/data-types/URI.test.ts
@@ -1,0 +1,40 @@
+import { fhirURITypeAdapter } from "./URI";
+
+describe("fhirURITypeAdapter", () => {
+  ["en-us", undefined].forEach((locale) => {
+    describe(`with ${locale} as locale`, () => {
+      const adapter = fhirURITypeAdapter(locale);
+
+      it("exposes the locale", () => {
+        expect(adapter.locale).toEqual(locale);
+      });
+
+      describe("parse and format", () => {
+        it.each([
+          "ftp://ftp.is.co.za/rfc/rfc1808.txt",
+          "http://www.ietf.org/rfc/rfc2396.txt",
+          "ldap://[2001:db8::7]/c=GB?objectClass?one",
+          "mailto:John.Doe@example.com",
+          "news:comp.infosystems.www.servers.unix",
+          "tel:+1-816-555-1212",
+          "telnet://192.0.2.16:80/",
+          "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
+        ])("parse %p", (value) => {
+          const parsedValue = adapter.parse(value);
+
+          expect(parsedValue).toEqual(new URL(value));
+          expect(adapter.format(parsedValue)).toEqual(value);
+          expect(adapter.format(value)).toEqual(value);
+        });
+      });
+    });
+  });
+
+  describe("with an unknown locale", () => {
+    it("raises an error", () => {
+      expect(() => fhirURITypeAdapter("nope")).toThrowError(
+        "Incorrect locale information provided"
+      );
+    });
+  });
+});

--- a/packages/core/r4b/data-types/URI.ts
+++ b/packages/core/r4b/data-types/URI.ts
@@ -1,0 +1,58 @@
+/**
+ * A Uniform Resource Identifier Reference
+ *
+ * @see https://hl7.org/fhir/datatypes.html#uri
+ */
+
+export type FhirURIFormatOptions = Record<string, never>;
+
+export type FhirURI = URL;
+
+export interface FhirURITypeAdapter {
+  locale: string | undefined;
+  /**
+   * Parse a FHIR URI
+   *
+   * @see https://hl7.org/fhir/datatypes.html#URI
+   */
+  parse(value: string | null | undefined): FhirURI | undefined;
+
+  /**
+   * Format a FHIR URI
+   *
+   * @see https://hl7.org/fhir/datatypes.html#URI
+   */
+  format(
+    value: FhirURI | string | null | undefined,
+    options?: FhirURIFormatOptions | null | undefined
+  ): string;
+}
+
+/**
+ * Return a {@link FhirURITypeAdapter}
+ *
+ * @param locale - see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument
+ */
+export function fhirURITypeAdapter(
+  locale?: string | undefined
+): FhirURITypeAdapter {
+  // JIT locale check
+  Intl.NumberFormat(locale);
+
+  return {
+    locale,
+    parse(value) {
+      if (!value?.trim()) {
+        return undefined;
+      }
+
+      return new URL(value);
+    },
+
+    format(value, _options) {
+      const fhirURI = value instanceof URL ? value : this.parse(value);
+
+      return fhirURI?.toString() || "";
+    },
+  };
+}

--- a/packages/core/r4b/data-types/URL.test.ts
+++ b/packages/core/r4b/data-types/URL.test.ts
@@ -1,0 +1,40 @@
+import { fhirURLTypeAdapter } from "./URL";
+
+describe("fhirURLTypeAdapter", () => {
+  ["en-us", undefined].forEach((locale) => {
+    describe(`with ${locale} as locale`, () => {
+      const adapter = fhirURLTypeAdapter(locale);
+
+      it("exposes the locale", () => {
+        expect(adapter.locale).toEqual(locale);
+      });
+
+      describe("parse and format", () => {
+        it.each([
+          "ftp://ftp.is.co.za/rfc/rfc1808.txt",
+          "http://www.ietf.org/rfc/rfc2396.txt",
+          "ldap://[2001:db8::7]/c=GB?objectClass?one",
+          "mailto:John.Doe@example.com",
+          "news:comp.infosystems.www.servers.unix",
+          "tel:+1-816-555-1212",
+          "telnet://192.0.2.16:80/",
+          "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
+        ])("parse %p", (value) => {
+          const parsedValue = adapter.parse(value);
+
+          expect(parsedValue).toEqual(new URL(value));
+          expect(adapter.format(parsedValue)).toEqual(value);
+          expect(adapter.format(value)).toEqual(value);
+        });
+      });
+    });
+  });
+
+  describe("with an unknown locale", () => {
+    it("raises an error", () => {
+      expect(() => fhirURLTypeAdapter("nope")).toThrowError(
+        "Incorrect locale information provided"
+      );
+    });
+  });
+});

--- a/packages/core/r4b/data-types/URL.ts
+++ b/packages/core/r4b/data-types/URL.ts
@@ -1,0 +1,58 @@
+/**
+ * A Uniform Resource Identifier Reference
+ *
+ * @see https://hl7.org/fhir/datatypes.html#url
+ */
+
+export type FhirURLFormatOptions = Record<string, never>;
+
+export type FhirURL = URL;
+
+export interface FhirURLTypeAdapter {
+  locale: string | undefined;
+  /**
+   * Parse a FHIR URL
+   *
+   * @see https://hl7.org/fhir/datatypes.html#URL
+   */
+  parse(value: string | null | undefined): FhirURL | undefined;
+
+  /**
+   * Format a FHIR URL
+   *
+   * @see https://hl7.org/fhir/datatypes.html#URL
+   */
+  format(
+    value: FhirURL | string | null | undefined,
+    options?: FhirURLFormatOptions | null | undefined
+  ): string;
+}
+
+/**
+ * Return a {@link FhirURLTypeAdapter}
+ *
+ * @param locale - see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument
+ */
+export function fhirURLTypeAdapter(
+  locale?: string | undefined
+): FhirURLTypeAdapter {
+  // JIT locale check
+  Intl.NumberFormat(locale);
+
+  return {
+    locale,
+    parse(value) {
+      if (!value?.trim()) {
+        return undefined;
+      }
+
+      return new URL(value);
+    },
+
+    format(value, _options) {
+      const fhirURL = value instanceof URL ? value : this.parse(value);
+
+      return fhirURL?.toString() || "";
+    },
+  };
+}

--- a/packages/core/r4b/data-types/canonical.test.ts
+++ b/packages/core/r4b/data-types/canonical.test.ts
@@ -1,0 +1,40 @@
+import { fhirCanonicalTypeAdapter } from "./canonical";
+
+describe("fhirCanonicalTypeAdapter", () => {
+  ["en-us", undefined].forEach((locale) => {
+    describe(`with ${locale} as locale`, () => {
+      const adapter = fhirCanonicalTypeAdapter(locale);
+
+      it("exposes the locale", () => {
+        expect(adapter.locale).toEqual(locale);
+      });
+
+      describe("parse and format", () => {
+        it.each([
+          "ftp://ftp.is.co.za/rfc/rfc1808.txt",
+          "http://www.ietf.org/rfc/rfc2396.txt",
+          "ldap://[2001:db8::7]/c=GB?objectClass?one",
+          "mailto:John.Doe@example.com",
+          "news:comp.infosystems.www.servers.unix",
+          "tel:+1-816-555-1212",
+          "telnet://192.0.2.16:80/",
+          "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
+        ])("parse %p", (value) => {
+          const parsedValue = adapter.parse(value);
+
+          expect(parsedValue).toEqual(new URL(value));
+          expect(adapter.format(parsedValue)).toEqual(value);
+          expect(adapter.format(value)).toEqual(value);
+        });
+      });
+    });
+  });
+
+  describe("with an unknown locale", () => {
+    it("raises an error", () => {
+      expect(() => fhirCanonicalTypeAdapter("nope")).toThrowError(
+        "Incorrect locale information provided"
+      );
+    });
+  });
+});

--- a/packages/core/r4b/data-types/canonical.ts
+++ b/packages/core/r4b/data-types/canonical.ts
@@ -1,0 +1,58 @@
+/**
+ * A Uniform Resource Identifier Reference
+ *
+ * @see https://hl7.org/fhir/datatypes.html#canonical
+ */
+
+export type FhirCanonicalFormatOptions = Record<string, never>;
+
+export type FhirCanonical = URL;
+
+export interface FhirCanonicalTypeAdapter {
+  locale: string | undefined;
+  /**
+   * Parse a FHIR Canonical
+   *
+   * @see https://hl7.org/fhir/datatypes.html#Canonical
+   */
+  parse(value: string | null | undefined): FhirCanonical | undefined;
+
+  /**
+   * Format a FHIR Canonical
+   *
+   * @see https://hl7.org/fhir/datatypes.html#Canonical
+   */
+  format(
+    value: FhirCanonical | string | null | undefined,
+    options?: FhirCanonicalFormatOptions | null | undefined
+  ): string;
+}
+
+/**
+ * Return a {@link FhirCanonicalTypeAdapter}
+ *
+ * @param locale - see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument
+ */
+export function fhirCanonicalTypeAdapter(
+  locale?: string | undefined
+): FhirCanonicalTypeAdapter {
+  // JIT locale check
+  Intl.NumberFormat(locale);
+
+  return {
+    locale,
+    parse(value) {
+      if (!value?.trim()) {
+        return undefined;
+      }
+
+      return new URL(value);
+    },
+
+    format(value, _options) {
+      const fhirCanonical = value instanceof URL ? value : this.parse(value);
+
+      return fhirCanonical?.toString() || "";
+    },
+  };
+}

--- a/packages/eslint-config/eslint.cjs
+++ b/packages/eslint-config/eslint.cjs
@@ -14,4 +14,32 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint/eslint-plugin"],
   root: true,
+  rules: {
+    // https://stackoverflow.com/a/64067915/5397051
+    // Allow unused params if they start with _
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+        caughtErrorsIgnorePattern: "^_",
+      },
+    ],
+    // forbid usage of unused variables (marked with an _)
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        selector: ["parameter", "variable"],
+        leadingUnderscore: "forbid",
+        format: null,
+      },
+      {
+        selector: "parameter",
+        leadingUnderscore: "require",
+        format: null,
+        modifiers: ["unused"],
+      },
+    ],
+  },
 };


### PR DESCRIPTION
## What is this about

introduce uri, URL and canonical support

For now they are all the same, making use of the mdn URL 

### questions:

Not sure about the case of things. @julienblin what's your take