### PR TITLE
ESM & CJS build

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,14 +1,11 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "targetDefaults": {
-    "build": {
-      "dependsOn": ["^build"]
+    "package:create": {
+      "dependsOn": ["build"]
     },
-    "check": {
-      "dependsOn": ["^build"]
-    },
-    "test": {
-      "dependsOn": ["^build"]
+    "package:publish": {
+      "dependsOn": ["build"]
     }
   },
   "tasksRunnerOptions": {

--- a/nx.json
+++ b/nx.json
@@ -1,13 +1,6 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
-  "targetDefaults": {
-    "package:create": {
-      "dependsOn": ["build"]
-    },
-    "package:publish": {
-      "dependsOn": ["build"]
-    }
-  },
+  "targetDefaults": {},
   "tasksRunnerOptions": {
     "default": {
       "runner": "nx/tasks-runners/default"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "clean": "lerna run clean",
     "codegen": "lerna run codegen",
     "commit": "commit",
+    "format": "lerna run format",
     "graph": "nx graph",
     "postinstall": "husky install",
     "test": "lerna run test",

--- a/packages/charlson-comorbidity-index/package.js
+++ b/packages/charlson-comorbidity-index/package.js
@@ -36,6 +36,12 @@ const execAsync = promisify(exec);
     join(distDirectory, "README.md")
   );
 
+  // Copy CHANGELOG.md
+  await copyFile(
+    join(rootPackageDirectory, "CHANGELOG.md"),
+    join(distDirectory, "CHANGELOG.md")
+  );
+
   // Delete TypeScript build info
   try {
     await unlink(join(distDirectory, "tsconfig.build.tsbuildinfo"));

--- a/packages/charlson-comorbidity-index/package.json
+++ b/packages/charlson-comorbidity-index/package.json
@@ -6,12 +6,20 @@
   "license": "APACHE-2.0",
   "type": "module",
   "scripts": {
-    "build": "yarn clean && tsc --project tsconfig.build.json",
+    "build": "yarn clean && tsup r4b/index.ts --format esm,cjs --out-dir dist/r4b --shims --dts --tsconfig tsconfig.build.json",
     "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
     "clean": "rimraf dist/",
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish",
     "test": "jest"
+  },
+  "exports": {
+    "./r4b": {
+      "types": "./r4b/index.d.ts",
+      "require": "./r4b/index.cjs",
+      "import": "./r4b/index.js",
+      "default": "./r4b/index.js"
+    }
   },
   "packageManager": "yarn@3.3.1",
   "devDependencies": {
@@ -32,6 +40,7 @@
     "jest": "^29.3.1",
     "prettier": "^2.8.1",
     "rimraf": "^3.0.2",
+    "tsup": "^6.6.2",
     "typescript": "^4.9.4"
   },
   "dependencies": {

--- a/packages/charlson-comorbidity-index/package.json
+++ b/packages/charlson-comorbidity-index/package.json
@@ -10,17 +10,9 @@
     "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
     "clean": "rimraf dist/",
     "format": "prettier --loglevel warn --write ./**/*.ts && eslint --fix ./**/*.ts",
-    "package:create": "node package.js pack",
-    "package:publish": "node package.js publish",
+    "package:create": "yarn build && node package.js pack",
+    "package:publish": "yarn build && node package.js publish",
     "test": "jest"
-  },
-  "exports": {
-    "./r4b": {
-      "types": "./r4b/index.d.ts",
-      "require": "./r4b/index.cjs",
-      "import": "./r4b/index.js",
-      "default": "./r4b/index.js"
-    }
   },
   "packageManager": "yarn@3.3.1",
   "devDependencies": {

--- a/packages/charlson-comorbidity-index/package.json
+++ b/packages/charlson-comorbidity-index/package.json
@@ -9,6 +9,7 @@
     "build": "yarn clean && tsup r4b/index.ts --format esm,cjs --out-dir dist/r4b --shims --dts --tsconfig tsconfig.build.json",
     "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
     "clean": "rimraf dist/",
+    "format": "prettier --loglevel warn --write ./**/*.ts && eslint --fix ./**/*.ts",
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish",
     "test": "jest"

--- a/packages/charlson-comorbidity-index/tsconfig.build.json
+++ b/packages/charlson-comorbidity-index/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "exclude": ["**/*.test.ts", "**/__fixtures__"],
   "compilerOptions": {
+    "incremental": false,
     "outDir": "dist"
   }
 }

--- a/packages/cmsdotgov/package.js
+++ b/packages/cmsdotgov/package.js
@@ -36,6 +36,12 @@ const execAsync = promisify(exec);
     join(distDirectory, "README.md")
   );
 
+  // Copy CHANGELOG.md
+  await copyFile(
+    join(rootPackageDirectory, "CHANGELOG.md"),
+    join(distDirectory, "CHANGELOG.md")
+  );
+
   // Delete TypeScript build info
   try {
     await unlink(join(distDirectory, "tsconfig.build.tsbuildinfo"));

--- a/packages/cmsdotgov/package.json
+++ b/packages/cmsdotgov/package.json
@@ -6,12 +6,20 @@
   "license": "APACHE-2.0",
   "type": "module",
   "scripts": {
-    "build": "yarn clean && tsc --project tsconfig.build.json",
+    "build": "yarn clean && tsup r4b/index.ts --format esm,cjs --out-dir dist/r4b --shims --dts --tsconfig tsconfig.build.json",
     "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
     "clean": "rimraf dist/",
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish",
     "test": "jest"
+  },
+  "exports": {
+    "./r4b": {
+      "types": "./r4b/index.d.ts",
+      "require": "./r4b/index.cjs",
+      "import": "./r4b/index.js",
+      "default": "./r4b/index.js"
+    }
   },
   "packageManager": "yarn@3.3.1",
   "devDependencies": {
@@ -31,6 +39,7 @@
     "jest": "^29.3.1",
     "prettier": "^2.8.1",
     "rimraf": "^3.0.2",
+    "tsup": "^6.6.2",
     "typescript": "^4.9.4"
   },
   "dependencies": {

--- a/packages/cmsdotgov/package.json
+++ b/packages/cmsdotgov/package.json
@@ -10,17 +10,9 @@
     "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
     "clean": "rimraf dist/",
     "format": "prettier --loglevel warn --write ./**/*.ts && eslint --fix ./**/*.ts",
-    "package:create": "node package.js pack",
-    "package:publish": "node package.js publish",
+    "package:create": "yarn build && node package.js pack",
+    "package:publish": "yarn build && node package.js publish",
     "test": "jest"
-  },
-  "exports": {
-    "./r4b": {
-      "types": "./r4b/index.d.ts",
-      "require": "./r4b/index.cjs",
-      "import": "./r4b/index.js",
-      "default": "./r4b/index.js"
-    }
   },
   "packageManager": "yarn@3.3.1",
   "devDependencies": {

--- a/packages/cmsdotgov/package.json
+++ b/packages/cmsdotgov/package.json
@@ -9,6 +9,7 @@
     "build": "yarn clean && tsup r4b/index.ts --format esm,cjs --out-dir dist/r4b --shims --dts --tsconfig tsconfig.build.json",
     "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
     "clean": "rimraf dist/",
+    "format": "prettier --loglevel warn --write ./**/*.ts && eslint --fix ./**/*.ts",
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish",
     "test": "jest"

--- a/packages/cmsdotgov/tsconfig.build.json
+++ b/packages/cmsdotgov/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "exclude": ["**/*.test.ts", "**/__fixtures__"],
   "compilerOptions": {
+    "incremental": false,
     "outDir": "dist"
   }
 }

--- a/packages/codegen/package.js
+++ b/packages/codegen/package.js
@@ -36,6 +36,12 @@ const execAsync = promisify(exec);
     join(distDirectory, "README.md")
   );
 
+  // Copy CHANGELOG.md
+  await copyFile(
+    join(rootPackageDirectory, "CHANGELOG.md"),
+    join(distDirectory, "CHANGELOG.md")
+  );
+
   // Delete TypeScript build info
   try {
     await unlink(join(distDirectory, "tsconfig.build.tsbuildinfo"));

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -13,6 +13,7 @@
     "check": "prettier --check ./src && eslint ./src && tsc --noEmit",
     "clean": "rimraf dist/",
     "dev": "ts-node --esm --swc --transpileOnly --experimental-specifier-resolution=node src/index.ts",
+    "format": "prettier --loglevel warn --write ./**/*.ts && eslint --fix ./**/*.ts",
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish",
     "test": "jest"

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -14,8 +14,8 @@
     "clean": "rimraf dist/",
     "dev": "ts-node --esm --swc --transpileOnly --experimental-specifier-resolution=node src/index.ts",
     "format": "prettier --loglevel warn --write ./**/*.ts && eslint --fix ./**/*.ts",
-    "package:create": "node package.js pack",
-    "package:publish": "node package.js publish",
+    "package:create": "yarn build && node package.js pack",
+    "package:publish": "yarn build && node package.js publish",
     "test": "jest"
   },
   "packageManager": "yarn@3.3.1",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -9,7 +9,7 @@
     "bonfhir-codegen": "index.js"
   },
   "scripts": {
-    "build": "yarn clean && tsc --project tsconfig.build.json",
+    "build": "yarn clean && tsup src/index.ts --format esm,cjs --out-dir dist/ --shims --dts --tsconfig tsconfig.build.json",
     "check": "prettier --check ./src && eslint ./src && tsc --noEmit",
     "clean": "rimraf dist/",
     "dev": "ts-node --esm --swc --transpileOnly --experimental-specifier-resolution=node src/index.ts",
@@ -38,6 +38,7 @@
     "prettier": "^2.8.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.1",
+    "tsup": "^6.6.2",
     "typescript": "^4.9.4"
   },
   "dependencies": {

--- a/packages/codegen/tsconfig.build.json
+++ b/packages/codegen/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "exclude": ["**/*.test.ts", "**/__fixtures__"],
   "compilerOptions": {
+    "incremental": false,
     "outDir": "dist"
   }
 }

--- a/packages/core/package.js
+++ b/packages/core/package.js
@@ -36,6 +36,12 @@ const execAsync = promisify(exec);
     join(distDirectory, "README.md")
   );
 
+  // Copy CHANGELOG.md
+  await copyFile(
+    join(rootPackageDirectory, "CHANGELOG.md"),
+    join(distDirectory, "CHANGELOG.md")
+  );
+
   // Delete TypeScript build info
   try {
     await unlink(join(distDirectory, "tsconfig.build.tsbuildinfo"));

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,13 +6,21 @@
   "license": "APACHE-2.0",
   "type": "module",
   "scripts": {
-    "build": "yarn clean && tsc --project tsconfig.build.json",
+    "build": "yarn clean && tsup r4b/index.ts --format esm,cjs --out-dir dist/r4b --shims --dts --tsconfig tsconfig.build.json",
     "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
     "clean": "rimraf dist/",
     "codegen": "yarn workspace @bonfhir/codegen run dev run -d \"${PWD}/../../fhir/r4b/definitions/**/*.json\" -t \"${PWD}/r4b/**/*.hbs\" --helpers \"${PWD}/template-helpers.js\" -p 'prettier --write %files%'",
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish",
     "test": "jest"
+  },
+  "exports": {
+    "./r4b": {
+      "types": "./r4b/index.d.ts",
+      "require": "./r4b/index.cjs",
+      "import": "./r4b/index.js",
+      "default": "./r4b/index.js"
+    }
   },
   "packageManager": "yarn@3.3.1",
   "devDependencies": {
@@ -22,18 +30,18 @@
     "@bonfhir/typescript-config": "^1.0.0",
     "@swc/core": "^1.3.24",
     "@swc/jest": "^0.2.24",
-    "@types/fhir": "^0.0.35",
     "@types/node": "^18.11.18",
     "@types/rimraf": "^3",
-    "date-fns": "^2.29.3",
     "eslint": "^8.30.0",
     "jest": "^29.3.1",
     "jest-mock-extended": "^3.0.1",
     "prettier": "^2.8.1",
     "rimraf": "^3.0.2",
+    "tsup": "^6.6.2",
     "typescript": "^4.9.4"
   },
   "dependencies": {
+    "@types/fhir": "^0.0.35",
     "fhirpath": "^3.3.1",
     "html-entities": "^2.3.3"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,17 +11,9 @@
     "clean": "rimraf dist/",
     "codegen": "yarn workspace @bonfhir/codegen run dev run -d \"${PWD}/../../fhir/r4b/definitions/**/*.json\" -t \"${PWD}/r4b/**/*.hbs\" --helpers \"${PWD}/template-helpers.js\" -p 'prettier --write %files%'",
     "format": "prettier --loglevel warn --write ./**/*.ts && eslint --fix ./**/*.ts",
-    "package:create": "node package.js pack",
-    "package:publish": "node package.js publish",
+    "package:create": "yarn build && node package.js pack",
+    "package:publish": "yarn build && node package.js publish",
     "test": "jest"
-  },
-  "exports": {
-    "./r4b": {
-      "types": "./r4b/index.d.ts",
-      "require": "./r4b/index.cjs",
-      "import": "./r4b/index.js",
-      "default": "./r4b/index.js"
-    }
   },
   "packageManager": "yarn@3.3.1",
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
     "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
     "clean": "rimraf dist/",
     "codegen": "yarn workspace @bonfhir/codegen run dev run -d \"${PWD}/../../fhir/r4b/definitions/**/*.json\" -t \"${PWD}/r4b/**/*.hbs\" --helpers \"${PWD}/template-helpers.js\" -p 'prettier --write %files%'",
+    "format": "prettier --loglevel warn --write ./**/*.ts && eslint --fix ./**/*.ts",
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish",
     "test": "jest"

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "exclude": ["**/*.test.ts", "**/__fixtures__"],
   "compilerOptions": {
+    "incremental": false,
     "outDir": "dist"
   }
 }

--- a/packages/docs/contributing/contributing.md
+++ b/packages/docs/contributing/contributing.md
@@ -54,8 +54,11 @@ Individual packages can be found in the [packages](https://github.com/bonfhir/bo
 
 Each package should expose a list of standard [scripts](https://yarnpkg.com/configuration/manifest/#scripts):
 
-- `yarn build`: Create a production build of the code (compiled with TypeScript)
+- `yarn build`: Create a production build of the code
 - `yarn check`: Run quality checks: [Prettier](https://prettier.io/), [ESLint](https://eslint.org/) and [type checking](https://www.typescriptlang.org/docs/handbook/compiler-options.html#using-the-cli)
 - `yarn clean`: Clean artifacts related to the build process; may be invoked automatically by the `build` script
 - `yarn codegen`: Run the [code generation](codegen) on the package source files, to generate source code
+- `yarn format`: Automatically format the code (using Prettier & ESLint); if you use the devcontainer this should be done automatically by VSCode
+- `yarn package:create`: Package the build to create a local NPM package
+- `yarn package:publish`: Package the build and publish to the NPM registry
 - `yarn test`: Run automated tests

--- a/packages/fhir-query/package.js
+++ b/packages/fhir-query/package.js
@@ -36,6 +36,12 @@ const execAsync = promisify(exec);
     join(distDirectory, "README.md")
   );
 
+  // Copy CHANGELOG.md
+  await copyFile(
+    join(rootPackageDirectory, "CHANGELOG.md"),
+    join(distDirectory, "CHANGELOG.md")
+  );
+
   // Delete TypeScript build info
   try {
     await unlink(join(distDirectory, "tsconfig.build.tsbuildinfo"));

--- a/packages/fhir-query/package.json
+++ b/packages/fhir-query/package.json
@@ -10,17 +10,9 @@
     "check": "prettier --check ./**/*.tsx && eslint ./**/*.tsx && tsc --noEmit",
     "clean": "rimraf dist/",
     "format": "prettier --loglevel warn --write ./**/*.tsx && eslint --fix ./**/*.tsx",
-    "package:create": "node package.js pack",
-    "package:publish": "node package.js publish",
+    "package:create": "yarn build && node package.js pack",
+    "package:publish": "yarn build && node package.js publish",
     "test": "jest"
-  },
-  "exports": {
-    "./r4b": {
-      "types": "./r4b/index.d.ts",
-      "require": "./r4b/index.cjs",
-      "import": "./r4b/index.js",
-      "default": "./r4b/index.js"
-    }
   },
   "packageManager": "yarn@3.3.1",
   "devDependencies": {

--- a/packages/fhir-query/package.json
+++ b/packages/fhir-query/package.json
@@ -6,12 +6,20 @@
   "license": "APACHE-2.0",
   "type": "module",
   "scripts": {
-    "build": "yarn clean && tsc --project tsconfig.build.json",
+    "build": "yarn clean && tsup r4b/index.tsx --format esm,cjs --out-dir dist/r4b --shims --dts --tsconfig tsconfig.build.json",
     "check": "prettier --check ./**/*.tsx && eslint ./**/*.tsx && tsc --noEmit",
     "clean": "rimraf dist/",
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish",
     "test": "jest"
+  },
+  "exports": {
+    "./r4b": {
+      "types": "./r4b/index.d.ts",
+      "require": "./r4b/index.cjs",
+      "import": "./r4b/index.js",
+      "default": "./r4b/index.js"
+    }
   },
   "packageManager": "yarn@3.3.1",
   "devDependencies": {
@@ -38,6 +46,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^3.0.2",
+    "tsup": "^6.6.2",
     "typescript": "^4.9.4"
   },
   "dependencies": {

--- a/packages/fhir-query/package.json
+++ b/packages/fhir-query/package.json
@@ -9,6 +9,7 @@
     "build": "yarn clean && tsup r4b/index.tsx --format esm,cjs --out-dir dist/r4b --shims --dts --tsconfig tsconfig.build.json",
     "check": "prettier --check ./**/*.tsx && eslint ./**/*.tsx && tsc --noEmit",
     "clean": "rimraf dist/",
+    "format": "prettier --loglevel warn --write ./**/*.tsx && eslint --fix ./**/*.tsx",
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish",
     "test": "jest"

--- a/packages/fhir-query/tsconfig.build.json
+++ b/packages/fhir-query/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/__fixtures__"],
   "compilerOptions": {
+    "incremental": false,
     "outDir": "dist"
   }
 }

--- a/packages/medplum/package.js
+++ b/packages/medplum/package.js
@@ -36,6 +36,12 @@ const execAsync = promisify(exec);
     join(distDirectory, "README.md")
   );
 
+  // Copy CHANGELOG.md
+  await copyFile(
+    join(rootPackageDirectory, "CHANGELOG.md"),
+    join(distDirectory, "CHANGELOG.md")
+  );
+
   // Delete TypeScript build info
   try {
     await unlink(join(distDirectory, "tsconfig.build.tsbuildinfo"));

--- a/packages/medplum/package.json
+++ b/packages/medplum/package.json
@@ -6,12 +6,20 @@
   "license": "APACHE-2.0",
   "type": "module",
   "scripts": {
-    "build": "yarn clean && tsc --project tsconfig.build.json",
+    "build": "yarn clean && tsup r4b/index.ts --format esm,cjs --out-dir dist/r4b --shims --dts --tsconfig tsconfig.build.json",
     "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
     "clean": "rimraf dist/",
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish",
     "test": "jest"
+  },
+  "exports": {
+    "./r4b": {
+      "types": "./r4b/index.d.ts",
+      "require": "./r4b/index.cjs",
+      "import": "./r4b/index.js",
+      "default": "./r4b/index.js"
+    }
   },
   "packageManager": "yarn@3.3.1",
   "devDependencies": {
@@ -28,6 +36,7 @@
     "jest": "^29.3.1",
     "prettier": "^2.8.1",
     "rimraf": "^3.0.2",
+    "tsup": "^6.6.2",
     "typescript": "^4.9.4"
   },
   "dependencies": {

--- a/packages/medplum/package.json
+++ b/packages/medplum/package.json
@@ -10,17 +10,9 @@
     "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
     "clean": "rimraf dist/",
     "format": "prettier --loglevel warn --write ./**/*.ts && eslint --fix ./**/*.ts",
-    "package:create": "node package.js pack",
-    "package:publish": "node package.js publish",
+    "package:create": "yarn build && node package.js pack",
+    "package:publish": "yarn build && node package.js publish",
     "test": "jest"
-  },
-  "exports": {
-    "./r4b": {
-      "types": "./r4b/index.d.ts",
-      "require": "./r4b/index.cjs",
-      "import": "./r4b/index.js",
-      "default": "./r4b/index.js"
-    }
   },
   "packageManager": "yarn@3.3.1",
   "devDependencies": {

--- a/packages/medplum/package.json
+++ b/packages/medplum/package.json
@@ -9,6 +9,7 @@
     "build": "yarn clean && tsup r4b/index.ts --format esm,cjs --out-dir dist/r4b --shims --dts --tsconfig tsconfig.build.json",
     "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
     "clean": "rimraf dist/",
+    "format": "prettier --loglevel warn --write ./**/*.ts && eslint --fix ./**/*.ts",
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish",
     "test": "jest"

--- a/packages/medplum/tsconfig.build.json
+++ b/packages/medplum/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "exclude": ["**/*.test.ts", "**/__fixtures__"],
   "compilerOptions": {
+    "incremental": false,
     "outDir": "dist"
   }
 }

--- a/packages/nih-nlm/package.js
+++ b/packages/nih-nlm/package.js
@@ -36,6 +36,12 @@ const execAsync = promisify(exec);
     join(distDirectory, "README.md")
   );
 
+  // Copy CHANGELOG.md
+  await copyFile(
+    join(rootPackageDirectory, "CHANGELOG.md"),
+    join(distDirectory, "CHANGELOG.md")
+  );
+
   // Delete TypeScript build info
   try {
     await unlink(join(distDirectory, "tsconfig.build.tsbuildinfo"));

--- a/packages/nih-nlm/package.json
+++ b/packages/nih-nlm/package.json
@@ -6,12 +6,20 @@
   "license": "APACHE-2.0",
   "type": "module",
   "scripts": {
-    "build": "yarn clean && tsc --project tsconfig.build.json",
+    "build": "yarn clean && tsup r4b/index.ts --format esm,cjs --out-dir dist/r4b --shims --dts --tsconfig tsconfig.build.json",
     "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
     "clean": "rimraf dist/",
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish",
     "test": "jest"
+  },
+  "exports": {
+    "./r4b": {
+      "types": "./r4b/index.d.ts",
+      "require": "./r4b/index.cjs",
+      "import": "./r4b/index.js",
+      "default": "./r4b/index.js"
+    }
   },
   "packageManager": "yarn@3.3.1",
   "devDependencies": {
@@ -31,6 +39,7 @@
     "jest": "^29.3.1",
     "prettier": "^2.8.1",
     "rimraf": "^3.0.2",
+    "tsup": "^6.6.2",
     "typescript": "^4.9.4"
   },
   "dependencies": {

--- a/packages/nih-nlm/package.json
+++ b/packages/nih-nlm/package.json
@@ -10,17 +10,9 @@
     "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
     "clean": "rimraf dist/",
     "format": "prettier --loglevel warn --write ./**/*.ts && eslint --fix ./**/*.ts",
-    "package:create": "node package.js pack",
-    "package:publish": "node package.js publish",
+    "package:create": "yarn build && node package.js pack",
+    "package:publish": "yarn build && node package.js publish",
     "test": "jest"
-  },
-  "exports": {
-    "./r4b": {
-      "types": "./r4b/index.d.ts",
-      "require": "./r4b/index.cjs",
-      "import": "./r4b/index.js",
-      "default": "./r4b/index.js"
-    }
   },
   "packageManager": "yarn@3.3.1",
   "devDependencies": {

--- a/packages/nih-nlm/package.json
+++ b/packages/nih-nlm/package.json
@@ -9,6 +9,7 @@
     "build": "yarn clean && tsup r4b/index.ts --format esm,cjs --out-dir dist/r4b --shims --dts --tsconfig tsconfig.build.json",
     "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
     "clean": "rimraf dist/",
+    "format": "prettier --loglevel warn --write ./**/*.ts && eslint --fix ./**/*.ts",
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish",
     "test": "jest"

--- a/packages/nih-nlm/tsconfig.build.json
+++ b/packages/nih-nlm/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "exclude": ["**/*.test.ts", "**/__fixtures__"],
   "compilerOptions": {
+    "incremental": false,
     "outDir": "dist"
   }
 }

--- a/packages/terminology/package.js
+++ b/packages/terminology/package.js
@@ -36,6 +36,12 @@ const execAsync = promisify(exec);
     join(distDirectory, "README.md")
   );
 
+  // Copy CHANGELOG.md
+  await copyFile(
+    join(rootPackageDirectory, "CHANGELOG.md"),
+    join(distDirectory, "CHANGELOG.md")
+  );
+
   // Delete TypeScript build info
   try {
     await unlink(join(distDirectory, "tsconfig.build.tsbuildinfo"));

--- a/packages/terminology/package.json
+++ b/packages/terminology/package.json
@@ -11,16 +11,8 @@
     "clean": "rimraf dist/",
     "codegen": "yarn workspace @bonfhir/codegen run dev run -d \"${PWD}/../../fhir/r4b/**/*.json\" -t \"${PWD}/r4b/**/*.ts.hbs\" --helpers \"${PWD}/template-helpers.js\" -p 'prettier --write %files%'",
     "format": "prettier --loglevel warn --write ./**/*.ts && eslint --fix ./**/*.ts",
-    "package:create": "node package.js pack",
-    "package:publish": "node package.js publish"
-  },
-  "exports": {
-    "./r4b": {
-      "types": "./r4b/index.d.ts",
-      "require": "./r4b/index.cjs",
-      "import": "./r4b/index.js",
-      "default": "./r4b/index.js"
-    }
+    "package:create": "yarn build && node package.js pack",
+    "package:publish": "yarn build && node package.js publish"
   },
   "packageManager": "yarn@3.3.1",
   "devDependencies": {

--- a/packages/terminology/package.json
+++ b/packages/terminology/package.json
@@ -6,12 +6,20 @@
   "license": "APACHE-2.0",
   "type": "module",
   "scripts": {
-    "build": "yarn clean && tsc --project tsconfig.build.json",
+    "build": "yarn clean && tsup r4b/index.ts --format esm,cjs --out-dir dist/r4b --shims --dts --tsconfig tsconfig.build.json",
     "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
     "clean": "rimraf dist/",
     "codegen": "yarn workspace @bonfhir/codegen run dev run -d \"${PWD}/../../fhir/r4b/**/*.json\" -t \"${PWD}/r4b/**/*.ts.hbs\" --helpers \"${PWD}/template-helpers.js\" -p 'prettier --write %files%'",
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish"
+  },
+  "exports": {
+    "./r4b": {
+      "types": "./r4b/index.d.ts",
+      "require": "./r4b/index.cjs",
+      "import": "./r4b/index.js",
+      "default": "./r4b/index.js"
+    }
   },
   "packageManager": "yarn@3.3.1",
   "devDependencies": {
@@ -29,6 +37,7 @@
     "jest": "^29.3.1",
     "prettier": "^2.8.1",
     "rimraf": "^3.0.2",
+    "tsup": "^6.6.2",
     "typescript": "^4.9.4"
   },
   "prettier": "@bonfhir/prettier-config"

--- a/packages/terminology/package.json
+++ b/packages/terminology/package.json
@@ -10,6 +10,7 @@
     "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
     "clean": "rimraf dist/",
     "codegen": "yarn workspace @bonfhir/codegen run dev run -d \"${PWD}/../../fhir/r4b/**/*.json\" -t \"${PWD}/r4b/**/*.ts.hbs\" --helpers \"${PWD}/template-helpers.js\" -p 'prettier --write %files%'",
+    "format": "prettier --loglevel warn --write ./**/*.ts && eslint --fix ./**/*.ts",
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish"
   },

--- a/packages/terminology/tsconfig.build.json
+++ b/packages/terminology/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "exclude": ["**/*.test.ts", "**/__fixtures__"],
   "compilerOptions": {
+    "incremental": false,
     "outDir": "dist"
   }
 }

--- a/packages/test-support/package.js
+++ b/packages/test-support/package.js
@@ -36,6 +36,12 @@ const execAsync = promisify(exec);
     join(distDirectory, "README.md")
   );
 
+  // Copy CHANGELOG.md
+  await copyFile(
+    join(rootPackageDirectory, "CHANGELOG.md"),
+    join(distDirectory, "CHANGELOG.md")
+  );
+
   // Delete TypeScript build info
   try {
     await unlink(join(distDirectory, "tsconfig.build.tsbuildinfo"));

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -11,17 +11,9 @@
     "clean": "rimraf dist/",
     "codegen": "yarn workspace @bonfhir/codegen run dev run -d \"${PWD}/../../fhir/r4b/definitions/**/*.json\" -t \"${PWD}/r4b/**/*.hbs\" --helpers \"${PWD}/template-helpers.js\" -p 'prettier --write %files%'",
     "format": "prettier --loglevel warn --write ./**/*.ts && eslint --fix ./**/*.ts",
-    "package:create": "node package.js pack",
-    "package:publish": "node package.js publish",
+    "package:create": "yarn build && node package.js pack",
+    "package:publish": "yarn build && node package.js publish",
     "test": "jest"
-  },
-  "exports": {
-    "./r4b": {
-      "types": "./r4b/index.d.ts",
-      "require": "./r4b/index.cjs",
-      "import": "./r4b/index.js",
-      "default": "./r4b/index.js"
-    }
   },
   "packageManager": "yarn@3.3.1",
   "devDependencies": {

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -6,13 +6,21 @@
   "license": "APACHE-2.0",
   "type": "module",
   "scripts": {
-    "build": "yarn clean && tsc --project tsconfig.build.json",
+    "build": "yarn clean && tsup r4b/index.ts --format esm,cjs --out-dir dist/r4b --shims --dts --tsconfig tsconfig.build.json",
     "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
     "clean": "rimraf dist/",
     "codegen": "yarn workspace @bonfhir/codegen run dev run -d \"${PWD}/../../fhir/r4b/definitions/**/*.json\" -t \"${PWD}/r4b/**/*.hbs\" --helpers \"${PWD}/template-helpers.js\" -p 'prettier --write %files%'",
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish",
     "test": "jest"
+  },
+  "exports": {
+    "./r4b": {
+      "types": "./r4b/index.d.ts",
+      "require": "./r4b/index.cjs",
+      "import": "./r4b/index.js",
+      "default": "./r4b/index.js"
+    }
   },
   "packageManager": "yarn@3.3.1",
   "devDependencies": {
@@ -30,6 +38,7 @@
     "jest": "^29.3.1",
     "prettier": "^2.8.1",
     "rimraf": "^3.0.2",
+    "tsup": "^6.6.2",
     "typescript": "^4.9.4"
   },
   "dependencies": {

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -10,6 +10,7 @@
     "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
     "clean": "rimraf dist/",
     "codegen": "yarn workspace @bonfhir/codegen run dev run -d \"${PWD}/../../fhir/r4b/definitions/**/*.json\" -t \"${PWD}/r4b/**/*.hbs\" --helpers \"${PWD}/template-helpers.js\" -p 'prettier --write %files%'",
+    "format": "prettier --loglevel warn --write ./**/*.ts && eslint --fix ./**/*.ts",
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish",
     "test": "jest"

--- a/packages/test-support/tsconfig.build.json
+++ b/packages/test-support/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "exclude": ["**/*.test.ts", "**/__fixtures__"],
   "compilerOptions": {
+    "incremental": false,
     "outDir": "dist"
   }
 }

--- a/packages/ui-components/package.js
+++ b/packages/ui-components/package.js
@@ -36,6 +36,12 @@ const execAsync = promisify(exec);
     join(distDirectory, "README.md")
   );
 
+  // Copy CHANGELOG.md
+  await copyFile(
+    join(rootPackageDirectory, "CHANGELOG.md"),
+    join(distDirectory, "CHANGELOG.md")
+  );
+
   // Delete TypeScript build info
   try {
     await unlink(join(distDirectory, "tsconfig.build.tsbuildinfo"));

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -11,6 +11,7 @@
     "check": "prettier --check ./**/*.tsx && eslint ./**/*.tsx && tsc --noEmit",
     "clean": "rimraf dist/ dist-ladle/",
     "dev": "ladle serve --stories='./**/*.stories.tsx'",
+    "format": "prettier --loglevel warn --write ./**/*.tsx && eslint --fix ./**/*.tsx",
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish",
     "test": "jest"

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -12,17 +12,9 @@
     "clean": "rimraf dist/ dist-ladle/",
     "dev": "ladle serve --stories='./**/*.stories.tsx'",
     "format": "prettier --loglevel warn --write ./**/*.tsx && eslint --fix ./**/*.tsx",
-    "package:create": "node package.js pack",
-    "package:publish": "node package.js publish",
+    "package:create": "yarn build && node package.js pack",
+    "package:publish": "yarn build && node package.js publish",
     "test": "jest"
-  },
-  "exports": {
-    "./r4b": {
-      "types": "./r4b/index.d.ts",
-      "require": "./r4b/index.cjs",
-      "import": "./r4b/index.js",
-      "default": "./r4b/index.js"
-    }
   },
   "packageManager": "yarn@3.3.1",
   "devDependencies": {

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -6,7 +6,7 @@
   "license": "APACHE-2.0",
   "type": "module",
   "scripts": {
-    "build": "yarn clean && tsc --project tsconfig.build.json && yarn build:ladle",
+    "build": "yarn clean && tsup r4b/index.tsx --format esm,cjs --out-dir dist/r4b --shims --dts --tsconfig tsconfig.build.json",
     "build:ladle": "ladle build --stories='./**/*.stories.tsx' --outDir dist-ladle/ --base /ui-components/dist-ladle",
     "check": "prettier --check ./**/*.tsx && eslint ./**/*.tsx && tsc --noEmit",
     "clean": "rimraf dist/ dist-ladle/",
@@ -14,6 +14,14 @@
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish",
     "test": "jest"
+  },
+  "exports": {
+    "./r4b": {
+      "types": "./r4b/index.d.ts",
+      "require": "./r4b/index.cjs",
+      "import": "./r4b/index.js",
+      "default": "./r4b/index.js"
+    }
   },
   "packageManager": "yarn@3.3.1",
   "devDependencies": {
@@ -41,6 +49,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^3.0.2",
+    "tsup": "^6.6.2",
     "typescript": "^4.9.4"
   },
   "dependencies": {
@@ -49,7 +58,6 @@
   },
   "prettier": "@bonfhir/prettier-config",
   "peerDependencies": {
-    "@tanstack/react-query": "^4.0.0",
     "react": "*",
     "react-dom": "*"
   }

--- a/packages/ui-components/tsconfig.build.json
+++ b/packages/ui-components/tsconfig.build.json
@@ -8,6 +8,7 @@
     "**/.ladle"
   ],
   "compilerOptions": {
+    "incremental": false,
     "outDir": "dist"
   }
 }

--- a/samples/ehr-sample-app/package.json
+++ b/samples/ehr-sample-app/package.json
@@ -11,6 +11,7 @@
     "build": "parcel build",
     "check": "prettier --check ./**/*.tsx && eslint ./**/*.tsx && tsc --noEmit",
     "clean": "rimraf dist/",
+    "format": "prettier --loglevel warn --write ./**/*.tsx && eslint --fix ./**/*.tsx",
     "package:create": "node package.js pack",
     "package:publish": "node package.js publish",
     "test": "jest"

--- a/samples/ehr-sample-app/package.json
+++ b/samples/ehr-sample-app/package.json
@@ -12,8 +12,6 @@
     "check": "prettier --check ./**/*.tsx && eslint ./**/*.tsx && tsc --noEmit",
     "clean": "rimraf dist/",
     "format": "prettier --loglevel warn --write ./**/*.tsx && eslint --fix ./**/*.tsx",
-    "package:create": "node package.js pack",
-    "package:publish": "node package.js publish",
     "test": "jest"
   },
   "source": "src/index.html",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1835,6 +1835,7 @@ __metadata:
     lodash: ^4.17.21
     prettier: ^2.8.1
     rimraf: ^3.0.2
+    tsup: ^6.6.2
     typescript: ^4.9.4
   languageName: unknown
   linkType: soft
@@ -1863,6 +1864,7 @@ __metadata:
     lodash: ^4.17.21
     prettier: ^2.8.1
     rimraf: ^3.0.2
+    tsup: ^6.6.2
     typescript: ^4.9.4
   languageName: unknown
   linkType: soft
@@ -1898,6 +1900,7 @@ __metadata:
     rimraf: ^3.0.2
     to-words: ^3.3.2
     ts-node: ^10.9.1
+    tsup: ^6.6.2
     typescript: ^4.9.4
     yargs: ^17.6.2
   bin:
@@ -1918,7 +1921,6 @@ __metadata:
     "@types/fhir": ^0.0.35
     "@types/node": ^18.11.18
     "@types/rimraf": ^3
-    date-fns: ^2.29.3
     eslint: ^8.30.0
     fhirpath: ^3.3.1
     html-entities: ^2.3.3
@@ -1926,6 +1928,7 @@ __metadata:
     jest-mock-extended: ^3.0.1
     prettier: ^2.8.1
     rimraf: ^3.0.2
+    tsup: ^6.6.2
     typescript: ^4.9.4
   languageName: unknown
   linkType: soft
@@ -2038,6 +2041,7 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     rimraf: ^3.0.2
+    tsup: ^6.6.2
     typescript: ^4.9.4
   peerDependencies:
     "@tanstack/react-query": ^4.0.0
@@ -2064,6 +2068,7 @@ __metadata:
     jest: ^29.3.1
     prettier: ^2.8.1
     rimraf: ^3.0.2
+    tsup: ^6.6.2
     typescript: ^4.9.4
   peerDependencies:
     "@medplum/core": ^2.0.0
@@ -2093,6 +2098,7 @@ __metadata:
     lodash: ^4.17.21
     prettier: ^2.8.1
     rimraf: ^3.0.2
+    tsup: ^6.6.2
     typescript: ^4.9.4
   languageName: unknown
   linkType: soft
@@ -2126,6 +2132,7 @@ __metadata:
     jest: ^29.3.1
     prettier: ^2.8.1
     rimraf: ^3.0.2
+    tsup: ^6.6.2
     typescript: ^4.9.4
   languageName: unknown
   linkType: soft
@@ -2152,6 +2159,7 @@ __metadata:
     jest: ^29.3.1
     prettier: ^2.8.1
     rimraf: ^3.0.2
+    tsup: ^6.6.2
     typescript: ^4.9.4
   languageName: unknown
   linkType: soft
@@ -2195,9 +2203,9 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     rimraf: ^3.0.2
+    tsup: ^6.6.2
     typescript: ^4.9.4
   peerDependencies:
-    "@tanstack/react-query": ^4.0.0
     react: "*"
     react-dom: "*"
   languageName: unknown
@@ -3051,9 +3059,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm64@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/android-arm64@npm:0.17.7"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm@npm:0.16.17":
   version: 0.16.17
   resolution: "@esbuild/android-arm@npm:0.16.17"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/android-arm@npm:0.17.7"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
@@ -3065,9 +3087,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-x64@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/android-x64@npm:0.17.7"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-arm64@npm:0.16.17":
   version: 0.16.17
   resolution: "@esbuild/darwin-arm64@npm:0.16.17"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/darwin-arm64@npm:0.17.7"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -3079,9 +3115,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-x64@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/darwin-x64@npm:0.17.7"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-arm64@npm:0.16.17":
   version: 0.16.17
   resolution: "@esbuild/freebsd-arm64@npm:0.16.17"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/freebsd-arm64@npm:0.17.7"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -3093,9 +3143,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-x64@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/freebsd-x64@npm:0.17.7"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm64@npm:0.16.17":
   version: 0.16.17
   resolution: "@esbuild/linux-arm64@npm:0.16.17"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/linux-arm64@npm:0.17.7"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
@@ -3107,9 +3171,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/linux-arm@npm:0.17.7"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ia32@npm:0.16.17":
   version: 0.16.17
   resolution: "@esbuild/linux-ia32@npm:0.16.17"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/linux-ia32@npm:0.17.7"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
@@ -3121,9 +3199,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-loong64@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/linux-loong64@npm:0.17.7"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-mips64el@npm:0.16.17":
   version: 0.16.17
   resolution: "@esbuild/linux-mips64el@npm:0.16.17"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/linux-mips64el@npm:0.17.7"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
@@ -3135,9 +3227,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ppc64@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/linux-ppc64@npm:0.17.7"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-riscv64@npm:0.16.17":
   version: 0.16.17
   resolution: "@esbuild/linux-riscv64@npm:0.16.17"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/linux-riscv64@npm:0.17.7"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
@@ -3149,9 +3255,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-s390x@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/linux-s390x@npm:0.17.7"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-x64@npm:0.16.17":
   version: 0.16.17
   resolution: "@esbuild/linux-x64@npm:0.16.17"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/linux-x64@npm:0.17.7"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
@@ -3163,9 +3283,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/netbsd-x64@npm:0.17.7"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openbsd-x64@npm:0.16.17":
   version: 0.16.17
   resolution: "@esbuild/openbsd-x64@npm:0.16.17"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/openbsd-x64@npm:0.17.7"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -3177,9 +3311,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/sunos-x64@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/sunos-x64@npm:0.17.7"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-arm64@npm:0.16.17":
   version: 0.16.17
   resolution: "@esbuild/win32-arm64@npm:0.16.17"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/win32-arm64@npm:0.17.7"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -3191,9 +3339,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/win32-ia32@npm:0.17.7"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-x64@npm:0.16.17":
   version: 0.16.17
   resolution: "@esbuild/win32-x64@npm:0.16.17"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.17.7":
+  version: 0.17.7
+  resolution: "@esbuild/win32-x64@npm:0.17.7"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -8080,6 +8242,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"any-promise@npm:^1.0.0":
+  version: 1.3.0
+  resolution: "any-promise@npm:1.3.0"
+  checksum: 0ee8a9bdbe882c90464d75d1f55cf027f5458650c4bd1f0467e65aec38ccccda07ca5844969ee77ed46d04e7dded3eaceb027e8d32f385688523fe305fa7e1de
+  languageName: node
+  linkType: hard
+
 "anymatch@npm:^3.0.3, anymatch@npm:~3.1.2":
   version: 3.1.3
   resolution: "anymatch@npm:3.1.3"
@@ -8984,6 +9153,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bundle-require@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "bundle-require@npm:4.0.1"
+  dependencies:
+    load-tsconfig: ^0.2.3
+  peerDependencies:
+    esbuild: ">=0.17"
+  checksum: 737217e37b72d7bee431b5d839b86ba604430f3ec346f073071de2ce65f0915189d4394ddd4685e0366b2930f38c95742b58c7101b8c53d9a8381d453f0b3b8a
+  languageName: node
+  linkType: hard
+
 "byte-size@npm:^7.0.0":
   version: 7.0.1
   resolution: "byte-size@npm:7.0.1"
@@ -9002,6 +9182,13 @@ __metadata:
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
   checksum: e4bcd3948d289c5127591fbedf10c0b639ccbf00243504e4e127374a15c3bc8eed0d28d4aaab08ff6f1cf2abc0cce6ba3085ed32f4f90e82a5683ce0014e1b6e
+  languageName: node
+  linkType: hard
+
+"cac@npm:^6.7.12":
+  version: 6.7.14
+  resolution: "cac@npm:6.7.14"
+  checksum: 45a2496a9443abbe7f52a49b22fbe51b1905eff46e03fd5e6c98e3f85077be3f8949685a1849b1a9cd2bc3e5567dfebcf64f01ce01847baf918f1b37c839791a
   languageName: node
   linkType: hard
 
@@ -9685,6 +9872,13 @@ __metadata:
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
+  languageName: node
+  linkType: hard
+
+"commander@npm:^4.0.0":
+  version: 4.1.1
+  resolution: "commander@npm:4.1.1"
+  checksum: d7b9913ff92cae20cb577a4ac6fcc121bd6223319e54a40f51a14740a681ad5c574fd29a57da478a5f234a6fa6c52cbf0b7c641353e03c648b1ae85ba670b977
   languageName: node
   linkType: hard
 
@@ -10512,13 +10706,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:^2.29.3":
-  version: 2.29.3
-  resolution: "date-fns@npm:2.29.3"
-  checksum: e01cf5b62af04e05dfff921bb9c9933310ed0e1ae9a81eb8653452e64dc841acf7f6e01e1a5ae5644d0337e9a7f936175fd2cb6819dc122fdd9c5e86c56be484
-  languageName: node
-  linkType: hard
-
 "date.js@npm:^0.3.1":
   version: 0.3.3
   resolution: "date.js@npm:0.3.3"
@@ -10551,7 +10738,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4":
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -11505,6 +11692,83 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 4c2cc609ecfb426554bc3f75beb92d89eb2d0c515cfceebaa36c7599d7dcaab7056b70f6d6b51e72b45951ddf9021ee28e356cf205f8e42cc055d522312ea30c
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.17.6":
+  version: 0.17.7
+  resolution: "esbuild@npm:0.17.7"
+  dependencies:
+    "@esbuild/android-arm": 0.17.7
+    "@esbuild/android-arm64": 0.17.7
+    "@esbuild/android-x64": 0.17.7
+    "@esbuild/darwin-arm64": 0.17.7
+    "@esbuild/darwin-x64": 0.17.7
+    "@esbuild/freebsd-arm64": 0.17.7
+    "@esbuild/freebsd-x64": 0.17.7
+    "@esbuild/linux-arm": 0.17.7
+    "@esbuild/linux-arm64": 0.17.7
+    "@esbuild/linux-ia32": 0.17.7
+    "@esbuild/linux-loong64": 0.17.7
+    "@esbuild/linux-mips64el": 0.17.7
+    "@esbuild/linux-ppc64": 0.17.7
+    "@esbuild/linux-riscv64": 0.17.7
+    "@esbuild/linux-s390x": 0.17.7
+    "@esbuild/linux-x64": 0.17.7
+    "@esbuild/netbsd-x64": 0.17.7
+    "@esbuild/openbsd-x64": 0.17.7
+    "@esbuild/sunos-x64": 0.17.7
+    "@esbuild/win32-arm64": 0.17.7
+    "@esbuild/win32-ia32": 0.17.7
+    "@esbuild/win32-x64": 0.17.7
+  dependenciesMeta:
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 5b019eebf71db2133eae984be1fb1734b18aaa7e3b13e50318e52b4c35e042e9db00da3ca0f257f6efc6acf262ecbd1f00435709df7520316d344acf26e3c710
   languageName: node
   linkType: hard
 
@@ -12910,6 +13174,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:7.1.6":
+  version: 7.1.6
+  resolution: "glob@npm:7.1.6"
+  dependencies:
+    fs.realpath: ^1.0.0
+    inflight: ^1.0.4
+    inherits: 2
+    minimatch: ^3.0.4
+    once: ^1.3.0
+    path-is-absolute: ^1.0.0
+  checksum: 351d549dd90553b87c2d3f90ce11aed9e1093c74130440e7ae0592e11bbcd2ce7f0ebb8ba6bfe63aaf9b62166a7f4c80cb84490ae5d78408bb2572bf7d4ee0a6
+  languageName: node
+  linkType: hard
+
 "glob@npm:^7.0.0, glob@npm:^7.0.5, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
@@ -13000,7 +13278,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.1, globby@npm:^11.0.2, globby@npm:^11.0.4, globby@npm:^11.1.0":
+"globby@npm:^11.0.1, globby@npm:^11.0.2, globby@npm:^11.0.3, globby@npm:^11.0.4, globby@npm:^11.1.0":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
   dependencies:
@@ -15468,6 +15746,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"joycon@npm:^3.0.1":
+  version: 3.1.1
+  resolution: "joycon@npm:3.1.1"
+  checksum: 8003c9c3fc79c5c7602b1c7e9f7a2df2e9916f046b0dbad862aa589be78c15734d11beb9fe846f5e06138df22cb2ad29961b6a986ba81c4920ce2b15a7f11067
+  languageName: node
+  linkType: hard
+
 "js-sdsl@npm:^4.1.4":
   version: 4.2.0
   resolution: "js-sdsl@npm:4.2.0"
@@ -15948,7 +16233,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lilconfig@npm:^2.0.3":
+"lilconfig@npm:^2.0.3, lilconfig@npm:^2.0.5":
   version: 2.0.6
   resolution: "lilconfig@npm:2.0.6"
   checksum: 40a3cd72f103b1be5975f2ac1850810b61d4053e20ab09be8d3aeddfe042187e1ba70b4651a7e70f95efa1642e7dc8b2ae395b317b7d7753b241b43cef7c0f7d
@@ -16070,6 +16355,13 @@ __metadata:
     strip-bom: ^4.0.0
     type-fest: ^0.6.0
   checksum: 4429e430ebb99375fc7cd936348e4f7ba729486080ced4272091c1e386a7f5f738ea3337d8ffd4b01c2f5bc3ddde92f2c780045b66838fe98bdb79f901884643
+  languageName: node
+  linkType: hard
+
+"load-tsconfig@npm:^0.2.3":
+  version: 0.2.3
+  resolution: "load-tsconfig@npm:0.2.3"
+  checksum: e28d1b2725fda76ee69fa4ee21b1257fd5b77b12e1be09cdc0b67f953e62ffbc3e7ac1a6267ec21309f95310cd10635e28a3cb38d04be3f7d683c4fe7914d7a9
   languageName: node
   linkType: hard
 
@@ -16231,6 +16523,13 @@ __metadata:
   version: 4.1.1
   resolution: "lodash.snakecase@npm:4.1.1"
   checksum: 1685ed3e83dda6eae5a4dcaee161a51cd210aabb3e1c09c57150e7dd8feda19e4ca0d27d0631eabe8d0f4eaa51e376da64e8c018ae5415417c5890d42feb72a8
+  languageName: node
+  linkType: hard
+
+"lodash.sortby@npm:^4.7.0":
+  version: 4.7.0
+  resolution: "lodash.sortby@npm:4.7.0"
+  checksum: db170c9396d29d11fe9a9f25668c4993e0c1331bcb941ddbd48fb76f492e732add7f2a47cfdf8e9d740fa59ac41bbfaf931d268bc72aab3ab49e9f89354d718c
   languageName: node
   linkType: hard
 
@@ -17059,6 +17358,17 @@ __metadata:
   version: 0.0.8
   resolution: "mute-stream@npm:0.0.8"
   checksum: ff48d251fc3f827e5b1206cda0ffdaec885e56057ee86a3155e1951bc940fd5f33531774b1cc8414d7668c10a8907f863f6561875ee6e8768931a62121a531a1
+  languageName: node
+  linkType: hard
+
+"mz@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "mz@npm:2.7.0"
+  dependencies:
+    any-promise: ^1.0.0
+    object-assign: ^4.0.1
+    thenify-all: ^1.0.0
+  checksum: 8427de0ece99a07e9faed3c0c6778820d7543e3776f9a84d22cf0ec0a8eb65f6e9aee9c9d353ff9a105ff62d33a9463c6ca638974cc652ee8140cd1e35951c87
   languageName: node
   linkType: hard
 
@@ -18366,7 +18676,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pirates@npm:^4.0.4":
+"pirates@npm:^4.0.1, pirates@npm:^4.0.4":
   version: 4.0.5
   resolution: "pirates@npm:4.0.5"
   checksum: c9994e61b85260bec6c4fc0307016340d9b0c4f4b6550a957afaaff0c9b1ad58fbbea5cfcf083860a25cb27a375442e2b0edf52e2e1e40e69934e08dcc52d227
@@ -18480,6 +18790,24 @@ __metadata:
   peerDependencies:
     postcss: ^8.2.15
   checksum: 5c09403a342a065033f5f22cefe6b402c76c2dc0aac31a736a2062d82c2a09f0ff2525b3df3a0c6f4e0ffc7a0392efd44bfe7f9d018e4cae30d15b818b216622
+  languageName: node
+  linkType: hard
+
+"postcss-load-config@npm:^3.0.1":
+  version: 3.1.4
+  resolution: "postcss-load-config@npm:3.1.4"
+  dependencies:
+    lilconfig: ^2.0.5
+    yaml: ^1.10.2
+  peerDependencies:
+    postcss: ">=8.0.9"
+    ts-node: ">=9.0.0"
+  peerDependenciesMeta:
+    postcss:
+      optional: true
+    ts-node:
+      optional: true
+  checksum: 1c589504c2d90b1568aecae8238ab993c17dba2c44f848a8f13619ba556d26a1c09644d5e6361b5784e721e94af37b604992f9f3dc0483e687a0cc1cc5029a34
   languageName: node
   linkType: hard
 
@@ -20805,6 +21133,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rollup@npm:^3.2.5":
+  version: 3.15.0
+  resolution: "rollup@npm:3.15.0"
+  dependencies:
+    fsevents: ~2.3.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 1a75b09503f705b594dcfebf65b9e1ca4536e3facdf5716e10d4272697b4bb7e6bd8ab35be1b3fe1271f864d4c4a75d012bd77cbe7a55579d5138258b9e85c23
+  languageName: node
+  linkType: hard
+
 "rtl-detect@npm:^1.0.4":
   version: 1.0.4
   resolution: "rtl-detect@npm:1.0.4"
@@ -21549,6 +21891,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map@npm:0.8.0-beta.0":
+  version: 0.8.0-beta.0
+  resolution: "source-map@npm:0.8.0-beta.0"
+  dependencies:
+    whatwg-url: ^7.0.0
+  checksum: e94169be6461ab0ac0913313ad1719a14c60d402bd22b0ad96f4a6cffd79130d91ab5df0a5336a326b04d2df131c1409f563c9dc0d21a6ca6239a44b6c8dbd92
+  languageName: node
+  linkType: hard
+
 "source-map@npm:^0.5.0, source-map@npm:^0.5.6":
   version: 0.5.7
   resolution: "source-map@npm:0.5.7"
@@ -22078,6 +22429,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sucrase@npm:^3.20.3":
+  version: 3.29.0
+  resolution: "sucrase@npm:3.29.0"
+  dependencies:
+    commander: ^4.0.0
+    glob: 7.1.6
+    lines-and-columns: ^1.1.6
+    mz: ^2.7.0
+    pirates: ^4.0.1
+    ts-interface-checker: ^0.1.9
+  bin:
+    sucrase: bin/sucrase
+    sucrase-node: bin/sucrase-node
+  checksum: fc8f04c34f29c0e9ca63109815df138182d62663dbe9565fcd94161b77a88a639f40c46559d0bb84d7acf9346ce23ea102476fd9168ec279330c7faecefb81eb
+  languageName: node
+  linkType: hard
+
 "superjson@npm:^1.10.0":
   version: 1.12.2
   resolution: "superjson@npm:1.12.2"
@@ -22311,6 +22679,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"thenify-all@npm:^1.0.0":
+  version: 1.6.0
+  resolution: "thenify-all@npm:1.6.0"
+  dependencies:
+    thenify: ">= 3.1.0 < 4"
+  checksum: dba7cc8a23a154cdcb6acb7f51d61511c37a6b077ec5ab5da6e8b874272015937788402fd271fdfc5f187f8cb0948e38d0a42dcc89d554d731652ab458f5343e
+  languageName: node
+  linkType: hard
+
+"thenify@npm:>= 3.1.0 < 4":
+  version: 3.3.1
+  resolution: "thenify@npm:3.3.1"
+  dependencies:
+    any-promise: ^1.0.0
+  checksum: 84e1b804bfec49f3531215f17b4a6e50fd4397b5f7c1bccc427b9c656e1ecfb13ea79d899930184f78bc2f57285c54d9a50a590c8868f4f0cef5c1d9f898b05e
+  languageName: node
+  linkType: hard
+
 "throttle-debounce@npm:^5.0.0":
   version: 5.0.0
   resolution: "throttle-debounce@npm:5.0.0"
@@ -22512,6 +22898,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tr46@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "tr46@npm:1.0.1"
+  dependencies:
+    punycode: ^2.1.0
+  checksum: 96d4ed46bc161db75dbf9247a236ea0bfcaf5758baae6749e92afab0bc5a09cb59af21788ede7e55080f2bf02dce3e4a8f2a484cc45164e29f4b5e68f7cbcc1a
+  languageName: node
+  linkType: hard
+
 "tr46@npm:^3.0.0":
   version: 3.0.0
   resolution: "tr46@npm:3.0.0"
@@ -22525,6 +22920,15 @@ __metadata:
   version: 0.0.3
   resolution: "tr46@npm:0.0.3"
   checksum: 726321c5eaf41b5002e17ffbd1fb7245999a073e8979085dacd47c4b4e8068ff5777142fc6726d6ca1fd2ff16921b48788b87225cbc57c72636f6efa8efbffe3
+  languageName: node
+  linkType: hard
+
+"tree-kill@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "tree-kill@npm:1.2.2"
+  bin:
+    tree-kill: cli.js
+  checksum: 49117f5f410d19c84b0464d29afb9642c863bc5ba40fcb9a245d474c6d5cc64d1b177a6e6713129eb346b40aebb9d4631d967517f9fbe8251c35b21b13cd96c7
   languageName: node
   linkType: hard
 
@@ -22578,6 +22982,13 @@ __metadata:
   peerDependencies:
     typescript: ">=3.7.0"
   checksum: 74d75868acf7f8b95e447d8b3b7442ca21738c6894e576df9917a352423fde5eb43c5651da5f78997da6061458160ae1f6b279150b42f47ccc58b73e55acaa2f
+  languageName: node
+  linkType: hard
+
+"ts-interface-checker@npm:^0.1.9":
+  version: 0.1.13
+  resolution: "ts-interface-checker@npm:0.1.13"
+  checksum: 20c29189c2dd6067a8775e07823ddf8d59a33e2ffc47a1bd59a5cb28bb0121a2969a816d5e77eda2ed85b18171aa5d1c4005a6b88ae8499ec7cc49f78571cb5e
   languageName: node
   linkType: hard
 
@@ -22656,6 +23067,42 @@ __metadata:
   version: 2.4.1
   resolution: "tslib@npm:2.4.1"
   checksum: 19480d6e0313292bd6505d4efe096a6b31c70e21cf08b5febf4da62e95c265c8f571f7b36fcc3d1a17e068032f59c269fab3459d6cd3ed6949eafecf64315fca
+  languageName: node
+  linkType: hard
+
+"tsup@npm:^6.6.2":
+  version: 6.6.2
+  resolution: "tsup@npm:6.6.2"
+  dependencies:
+    bundle-require: ^4.0.0
+    cac: ^6.7.12
+    chokidar: ^3.5.1
+    debug: ^4.3.1
+    esbuild: ^0.17.6
+    execa: ^5.0.0
+    globby: ^11.0.3
+    joycon: ^3.0.1
+    postcss-load-config: ^3.0.1
+    resolve-from: ^5.0.0
+    rollup: ^3.2.5
+    source-map: 0.8.0-beta.0
+    sucrase: ^3.20.3
+    tree-kill: ^1.2.2
+  peerDependencies:
+    "@swc/core": ^1
+    postcss: ^8.4.12
+    typescript: ^4.1.0
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    postcss:
+      optional: true
+    typescript:
+      optional: true
+  bin:
+    tsup: dist/cli-default.js
+    tsup-node: dist/cli-node.js
+  checksum: 80d52608f187d0cda8b8029acca52ed9da5f1152915f8e8b2c23efe1fb309a90229098005740596a6e30a91b3f270b39b3d81437d5a9b7b3d3e9ff8fc0aa98e6
   languageName: node
   linkType: hard
 
@@ -23485,6 +23932,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webidl-conversions@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "webidl-conversions@npm:4.0.2"
+  checksum: c93d8dfe908a0140a4ae9c0ebc87a33805b416a33ee638a605b551523eec94a9632165e54632f6d57a39c5f948c4bab10e0e066525e9a4b87a79f0d04fbca374
+  languageName: node
+  linkType: hard
+
 "webidl-conversions@npm:^7.0.0":
   version: 7.0.0
   resolution: "webidl-conversions@npm:7.0.0"
@@ -23696,6 +24150,17 @@ __metadata:
     tr46: ~0.0.3
     webidl-conversions: ^3.0.0
   checksum: b8daed4ad3356cc4899048a15b2c143a9aed0dfae1f611ebd55073310c7b910f522ad75d727346ad64203d7e6c79ef25eafd465f4d12775ca44b90fa82ed9e2c
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "whatwg-url@npm:7.1.0"
+  dependencies:
+    lodash.sortby: ^4.7.0
+    tr46: ^1.0.1
+    webidl-conversions: ^4.0.2
+  checksum: fecb07c87290b47d2ec2fb6d6ca26daad3c9e211e0e531dd7566e7ff95b5b3525a57d4f32640ad4adf057717e0c215731db842ad761e61d947e81010e05cf5fd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What is this about

This PR update the whole build mechanism to create ESM & CJS packages.
This version uses [tsup](https://tsup.egoist.dev/) and changes very few things, but it achieves the following goals:
 - ESM & CJS
 - keep the `r4b` (FHIR version) import mechanism
 - validated to work out-of-the-box with both `create-react-app` (ESM) and a default node app (CJS)
 - enable tree-shaking in ESM (so the webpack bundler in `create-react-app` is able to tree shake efficiently)
 - keep the current monorepo structure and inter-projects references

## Issue ticket numbers

Fix #40 

## How can this be tested?

Run `yarn build` and `yarn package:create` to create individual packages.

## Known limitations/edge cases

N/A
