### PR TITLE
fix(ui-components): :green_heart: fix building of ladle during CI

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -6,7 +6,7 @@
   "license": "APACHE-2.0",
   "type": "module",
   "scripts": {
-    "build": "yarn clean && tsup r4b/index.tsx --format esm,cjs --out-dir dist/r4b --shims --dts --tsconfig tsconfig.build.json",
+    "build": "yarn clean && tsup r4b/index.tsx --format esm,cjs --out-dir dist/r4b --shims --dts --tsconfig tsconfig.build.json && yarn build:ladle",
     "build:ladle": "ladle build --stories='./**/*.stories.tsx' --outDir dist-ladle/ --base /ui-components/dist-ladle",
     "check": "prettier --check ./**/*.tsx && eslint ./**/*.tsx && tsc --noEmit",
     "clean": "rimraf dist/ dist-ladle/",

--- a/packages/ui-components/vite.config.mjs
+++ b/packages/ui-components/vite.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import('vite').UserConfig} */
+export default {
+  build: {
+    chunkSizeWarningLimit: 2000,
+  },
+  logLevel: "error",
+};


### PR DESCRIPTION
## What is this about

This is a small Fix to have the ladle build back when running CI, so that it is picked up by the docs build.

## Issue ticket numbers

N/A

## How can this be tested?

N/A

## Known limitations/edge cases

N/A