### PR TITLE
feat(ui-components): :sparkles: add `valueSetExpand` option to `<FhirValue />`

### DIFF
--- a/packages/core/r4b/data-type-adapter.test.ts
+++ b/packages/core/r4b/data-type-adapter.test.ts
@@ -64,6 +64,13 @@ describe("intlFhirDataTypeAdapter", () => {
           { dateStyle: "long" },
         ]} guy.`
       ).toEqual("this is February 2, 2023 guy.");
+
+      expect(
+        adapter.message`the cost is ${[
+          { currency: "USD", value: 15 },
+          "money",
+        ]}`
+      ).toEqual("the cost is $15.00");
     });
   });
 });

--- a/packages/core/r4b/data-type-adapter.ts
+++ b/packages/core/r4b/data-type-adapter.ts
@@ -76,32 +76,31 @@ import { FhirURLTypeAdapter, fhirURLTypeAdapter } from "./data-types/URL";
  */
 export interface FhirDataTypeAdapter {
   locale: string | undefined;
-  // primitive types
-  code: FhirCodeTypeAdapter;
-  date: FhirDateTypeAdapter;
-  boolean: FhirBooleanTypeAdapter;
-  dateTime: FhirDateTimeTypeAdapter;
-  instant: FhirInstantTypeAdapter;
-  integer: FhirIntegerTypeAdapter;
-  decimal: FhirDecimalTypeAdapter;
-  uri: FhirURITypeAdapter;
-  url: FhirURLTypeAdapter;
-  canonical: FhirCanonicalTypeAdapter;
-  markdown: FhirMarkdownTypeAdapter;
-  // general-purpose types
-  money: FhirMoneyTypeAdapter;
-  period: FhirPeriodTypeAdapter;
+
   age: FhirAgeTypeAdapter;
+  boolean: FhirBooleanTypeAdapter;
+  canonical: FhirCanonicalTypeAdapter;
+  code: FhirCodeTypeAdapter;
+  codeableConcept: FhirCodeableConceptTypeAdapter;
+  coding: FhirCodingTypeAdapter;
   count: FhirCountTypeAdapter;
+  date: FhirDateTypeAdapter;
+  dateTime: FhirDateTimeTypeAdapter;
+  decimal: FhirDecimalTypeAdapter;
   distance: FhirDistanceTypeAdapter;
   duration: FhirDurationTypeAdapter;
+  instant: FhirInstantTypeAdapter;
+  integer: FhirIntegerTypeAdapter;
+  markdown: FhirMarkdownTypeAdapter;
+  money: FhirMoneyTypeAdapter;
+  period: FhirPeriodTypeAdapter;
   quantity: FhirQuantityTypeAdapter;
   range: FhirRangeTypeAdapter;
   ratio: FhirRatioTypeAdapter;
   ratioRange: FhirRatioRangeTypeAdapter;
   simpleQuantity: FhirSimpleQuantityTypeAdapter;
-  coding: FhirCodingTypeAdapter;
-  codeableConcept: FhirCodeableConceptTypeAdapter;
+  uri: FhirURITypeAdapter;
+  url: FhirURLTypeAdapter;
 
   message: (
     strings: TemplateStringsArray,
@@ -121,9 +120,30 @@ type MessageExpressionAdapter<
 
 export type FhirDataTypeAdapterMessageExpression =
   | string
+  | MessageExpressionAdapter<"age">
+  | MessageExpressionAdapter<"boolean">
+  | MessageExpressionAdapter<"canonical">
+  | MessageExpressionAdapter<"code">
+  | MessageExpressionAdapter<"codeableConcept">
+  | MessageExpressionAdapter<"coding">
+  | MessageExpressionAdapter<"count">
   | MessageExpressionAdapter<"date">
-  | MessageExpressionAdapter<"integer">
+  | MessageExpressionAdapter<"dateTime">
   | MessageExpressionAdapter<"decimal">
+  | MessageExpressionAdapter<"distance">
+  | MessageExpressionAdapter<"duration">
+  | MessageExpressionAdapter<"instant">
+  | MessageExpressionAdapter<"integer">
+  | MessageExpressionAdapter<"markdown">
+  | MessageExpressionAdapter<"money">
+  | MessageExpressionAdapter<"period">
+  | MessageExpressionAdapter<"quantity">
+  | MessageExpressionAdapter<"range">
+  | MessageExpressionAdapter<"ratio">
+  | MessageExpressionAdapter<"ratioRange">
+  | MessageExpressionAdapter<"simpleQuantity">
+  | MessageExpressionAdapter<"uri">
+  | MessageExpressionAdapter<"url">
   | null
   | undefined;
 
@@ -195,7 +215,8 @@ function renderExpression(
     const valueToFormat: any = value[0];
     const options = value[2];
 
-    return adapter[adapterName].format(valueToFormat, options);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return adapter[adapterName].format(valueToFormat, options as any);
   }
 
   return value.toString();

--- a/packages/ui-components/.ladle/components.tsx
+++ b/packages/ui-components/.ladle/components.tsx
@@ -1,7 +1,101 @@
+import { FhirRestfulClient } from "@bonfhir/core/r4b";
+import { FhirQueryProvider } from "@bonfhir/fhir-query/r4b";
 import type { GlobalProvider } from "@ladle/react";
+import { ValueSet } from "fhir/r4";
 import { FhirUIComponentsProvider } from "../r4b/FhirUIComponentsProvider";
+
+const staticFhirClient = {
+  execute(operation, options) {
+    if (
+      operation === "$expand" &&
+      options?.type === "ValueSet" &&
+      options?.parameters?.url === "http://hl7.org/fhir/ValueSet/marital-status"
+    ) {
+      return {
+        url: "http://hl7.org/fhir/ValueSet/marital-status",
+        expansion: {
+          contains: [
+            {
+              system: "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+              code: "A",
+              display: "Annulled",
+            },
+
+            {
+              system: "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+              code: "D",
+              display: "Divorced",
+            },
+
+            {
+              system: "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+              code: "I",
+              display: "Interlocutory",
+            },
+
+            {
+              system: "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+              code: "L",
+              display: "Legally Separated",
+            },
+
+            {
+              system: "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+              code: "M",
+              display: "Married",
+            },
+
+            {
+              system: "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+              code: "C",
+              display: "Common Law",
+            },
+
+            {
+              system: "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+              code: "P",
+              display: "Polygamous",
+            },
+
+            {
+              system: "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+              code: "T",
+              display: "Domestic partner",
+            },
+
+            {
+              system: "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+              code: "U",
+              display: "unmarried",
+            },
+
+            {
+              system: "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+              code: "S",
+              display: "Never Married",
+            },
+
+            {
+              system: "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+              code: "W",
+              display: "Widowed",
+            },
+
+            {
+              system: "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+              code: "UNK",
+              display: "unknown",
+            },
+          ],
+        },
+      } as ValueSet;
+    }
+  },
+} as unknown as FhirRestfulClient;
 
 // TODO Configure future FhirComponentProvider
 export const Provider: GlobalProvider = ({ children }) => (
-  <FhirUIComponentsProvider>{children}</FhirUIComponentsProvider>
+  <FhirQueryProvider fhirClient={staticFhirClient}>
+    <FhirUIComponentsProvider>{children}</FhirUIComponentsProvider>
+  </FhirQueryProvider>
 );

--- a/packages/ui-components/r4b/data-types/FhirValue.stories.tsx
+++ b/packages/ui-components/r4b/data-types/FhirValue.stories.tsx
@@ -1,9 +1,74 @@
 import { FhirValue } from "./FhirValue";
 
+export const CodeSimple = () => <FhirValue type="code" value="C" />;
+
+export const CodeWithExpand = () => (
+  <FhirValue
+    type="code"
+    value="C"
+    options={{
+      valueSetExpand: { url: "http://hl7.org/fhir/ValueSet/marital-status" },
+    }}
+  />
+);
+
+export const Coding = () => (
+  <FhirValue
+    type="coding"
+    value={{
+      code: "ADMIN",
+      display: "Administrative",
+      system: "http://hl7.org/fhir/ValueSet/contactentity-type",
+    }}
+  />
+);
+
+export const CodeableConcept = () => (
+  <FhirValue
+    type="codeableConcept"
+    value={{
+      coding: [
+        {
+          code: "ADMIN",
+          display: "Administrative",
+          system: "http://hl7.org/fhir/ValueSet/contactentity-type",
+        },
+      ],
+      text: "Administrative",
+    }}
+  />
+);
+
+export const Boolean = () => <FhirValue type="boolean" value={false} />;
+
+export const BooleanWithLabel = () => (
+  <FhirValue
+    type="boolean"
+    value={true}
+    options={{ labels: { true: "Yes", false: "No" } }}
+  />
+);
+
 export const Date = () => <FhirValue type="date" value="2023-01-01" />;
 
 export const DateFull = () => (
   <FhirValue type="date" value="2023-01-01" options={{ dateStyle: "full" }} />
+);
+
+export const Datetime = () => (
+  <FhirValue type="dateTime" value="2023-02-01T01:57:25.336Z" />
+);
+
+export const DatetimeFull = () => (
+  <FhirValue
+    type="dateTime"
+    value="2023-02-01T01:57:25.336Z"
+    options={{ dateStyle: "full", timeStyle: "full" }}
+  />
+);
+
+export const Instant = () => (
+  <FhirValue type="instant" value="2023-02-01T01:57:25.336Z" />
 );
 
 export const Integer = () => <FhirValue type="integer" value={123456789} />;
@@ -25,3 +90,109 @@ export const IntegerCompactLong = () => (
 );
 
 export const Decimal = () => <FhirValue type="decimal" value={"12.00"} />;
+
+export const Uri = () => <FhirValue type="uri" value="https://bonfhir.dev" />;
+
+export const Url = () => <FhirValue type="url" value="https://bonfhir.dev" />;
+
+export const Canonical = () => (
+  <FhirValue type="canonical" value="https://bonfhir.dev" />
+);
+
+export const Markdown = () => (
+  <FhirValue
+    type="markdown"
+    value={markdownSample}
+    options={{ style: "html" }}
+  />
+);
+
+export const Money = () => (
+  <FhirValue type="money" value={{ value: 50, currency: "USD" }} />
+);
+
+export const Period = () => (
+  <FhirValue type="period" value={{ start: "2023-01-01", end: "2023-03-20" }} />
+);
+
+export const Quantity = () => (
+  <FhirValue
+    type="quantity"
+    value={{ comparator: ">", value: 12, unit: "mg" }}
+  />
+);
+
+export const Range = () => (
+  <FhirValue
+    type="range"
+    value={{ low: { value: 12, unit: "mg" }, high: { value: 50, unit: "mg" } }}
+  />
+);
+
+export const Ratio = () => (
+  <FhirValue
+    type="ratio"
+    value={{ numerator: { value: 5 }, denominator: { value: 12 } }}
+  />
+);
+
+export const RatioRange = () => (
+  <FhirValue
+    type="ratioRange"
+    value={{
+      lowNumerator: { value: 5 },
+      highNumerator: { value: 8 },
+      denominator: { value: 12 },
+    }}
+  />
+);
+
+export const SimpleQuantity = () => (
+  <FhirValue
+    type="simpleQuantity"
+    value={{ value: 15, unit: "l", operator: null }}
+  />
+);
+
+export const Age = () => (
+  <FhirValue type="age" value={{ value: 25, code: "y" }} />
+);
+
+export const Count = () => (
+  <FhirValue type="count" value={{ value: 25, code: "cats" }} />
+);
+
+export const Distance = () => (
+  <FhirValue type="count" value={{ value: 25, code: "km" }} />
+);
+
+export const Duration = () => (
+  <FhirValue type="count" value={{ value: 25, code: "min." }} />
+);
+
+const markdownSample = `
+An h1 header
+============
+
+Paragraphs are separated by a blank line.
+
+2nd paragraph. *Italic*, **bold**, and \`monospace\`. Itemized lists
+look like:
+
+  * this one
+  * that one
+  * the other one
+
+Note that --- not considering the asterisk --- the actual text
+content starts at 4-columns in.
+
+> Block quotes are
+> written like so.
+>
+> They can span multiple paragraphs,
+> if you like.
+
+Use 3 dashes for an em-dash. Use 2 dashes for ranges (ex., "it's all
+in chapters 12--14"). Three dots ... will be converted to an ellipsis.
+Unicode is supported. ☺
+`;

--- a/packages/ui-components/r4b/data-types/FhirValue.tsx
+++ b/packages/ui-components/r4b/data-types/FhirValue.tsx
@@ -1,35 +1,131 @@
-import { FhirDataTypeAdapter } from "@bonfhir/core/r4b";
+import {
+  FhirDataTypeAdapter,
+  ValueSetExpandOperationParameters,
+  ValueSetExpandOperationResult,
+} from "@bonfhir/core/r4b";
+import { useFhirExecute } from "@bonfhir/fhir-query/r4b";
 import { ReactElement } from "react";
 import { useFhirUIComponentsContext } from "../FhirUIComponentsContext";
 
-export interface FhirValuePropsAdapter<
-  TAdapterName extends keyof Omit<FhirDataTypeAdapter, "locale" | "message">
-> {
+export interface FhirValuePropsCombination<TAdapterName, TValue, TOptions> {
   type: TAdapterName;
-  value:
-    | Parameters<FhirDataTypeAdapter[TAdapterName]["format"]>[0]
-    | null
-    | undefined;
-  options?:
-    | Parameters<FhirDataTypeAdapter[TAdapterName]["format"]>[1]
-    | null
-    | undefined;
+  value: TValue | null | undefined;
+  options?: TOptions | null | undefined;
 }
 
-export type FhirValueProps =
-  | FhirValuePropsAdapter<"date">
-  | FhirValuePropsAdapter<"decimal">
-  | FhirValuePropsAdapter<"integer">;
+export type FhirValuePropsAdapter<
+  TAdapterName extends keyof Omit<FhirDataTypeAdapter, "locale" | "message">
+> = FhirValuePropsCombination<
+  TAdapterName,
+  Parameters<FhirDataTypeAdapter[TAdapterName]["format"]>[0],
+  Parameters<FhirDataTypeAdapter[TAdapterName]["format"]>[1]
+>;
 
+export type FhirValuePropsAdapterValueSetExpand<
+  TAdapterName extends keyof Omit<FhirDataTypeAdapter, "locale" | "message">
+> = FhirValuePropsCombination<
+  TAdapterName,
+  Parameters<FhirDataTypeAdapter[TAdapterName]["format"]>[0],
+  Omit<
+    Parameters<FhirDataTypeAdapter[TAdapterName]["format"]>[1],
+    "valueSetExpansions"
+  > &
+    HasValueSetExpand
+>;
+
+export type HasValueSetExpand = {
+  valueSetExpand: ValueSetExpandOperationParameters;
+};
+
+export type FhirValueProps =
+  | FhirValuePropsAdapter<"code">
+  | FhirValuePropsAdapterValueSetExpand<"code">
+  | FhirValuePropsAdapter<"coding">
+  | FhirValuePropsAdapterValueSetExpand<"coding">
+  | FhirValuePropsAdapter<"codeableConcept">
+  | FhirValuePropsAdapterValueSetExpand<"codeableConcept">
+  | FhirValuePropsAdapter<"boolean">
+  | FhirValuePropsAdapter<"date">
+  | FhirValuePropsAdapter<"dateTime">
+  | FhirValuePropsAdapter<"instant">
+  | FhirValuePropsAdapter<"integer">
+  | FhirValuePropsAdapter<"decimal">
+  | FhirValuePropsAdapter<"uri">
+  | FhirValuePropsAdapter<"url">
+  | FhirValuePropsAdapter<"canonical">
+  | FhirValuePropsAdapter<"markdown">
+  | FhirValuePropsAdapter<"money">
+  | FhirValuePropsAdapter<"period">
+  | FhirValuePropsAdapter<"quantity">
+  | FhirValuePropsAdapter<"range">
+  | FhirValuePropsAdapter<"ratio">
+  | FhirValuePropsAdapter<"ratioRange">
+  | FhirValuePropsAdapter<"simpleQuantity">
+  | FhirValuePropsAdapter<"age">
+  | FhirValuePropsAdapter<"count">
+  | FhirValuePropsAdapter<"distance">
+  | FhirValuePropsAdapter<"duration">;
+
+/**
+ * Render a [FHIR datatype](https://hl7.org/fhir/datatypes.html) as a string, using the context
+ * `dataTypeAdapter`.
+ *
+ * All options applicable to {@link FhirDataTypeAdapter} can be used here.
+ *
+ * Additionally, for data types where it makes sense, you can specify a `valueSetExpand` option that will trigger
+ * the `$expand`operation on the server to fetch the expanded values.
+ *
+ * @example
+ *
+ *  <FhirValue type="date" value={patient.birthDate} options={{ dateStyle: "long" }} />
+ *
+ *  <FhirValue type="code" value={patient.gender} options={{ valueSetExpand: { url: "http://hl7.org/fhir/ValueSet/administrative-gender" }}} />
+ */
 export function FhirValue(props: FhirValueProps): ReactElement | null {
   const uiContext = useFhirUIComponentsContext();
+
+  const { valueSetExpand, ...options } =
+    (props.options as HasValueSetExpand) || {};
+
+  const valueSetExpandQuery = useFhirExecute<
+    ValueSetExpandOperationResult,
+    ValueSetExpandOperationParameters
+  >(
+    "$expand",
+    { type: "ValueSet", parameters: valueSetExpand },
+    {
+      enabled: !!valueSetExpand,
+      cacheTime: Infinity,
+    }
+  );
+
+  if (props.type === "markdown" && props.options?.style === "html") {
+    // TODO: make it safer
+    return (
+      <div
+        dangerouslySetInnerHTML={{
+          __html: uiContext.dataTypeAdapter.markdown.format(
+            props.value,
+            props.options
+          ),
+        }}
+      />
+    );
+  }
 
   return (
     <>
       {uiContext.dataTypeAdapter[props.type].format(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         props.value as any,
-        props.options
+        {
+          ...options,
+          valueSetExpansions:
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (options as any).valueSetExpansions ||
+            valueSetExpandQuery.data?.expansion?.contains,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any
       )}
     </>
   );

--- a/samples/ehr-sample-app/src/pages/patients/Patients.tsx
+++ b/samples/ehr-sample-app/src/pages/patients/Patients.tsx
@@ -21,7 +21,22 @@ export function Patients(): ReactElement | null {
         {patientsQuery.data?.nav.type("Patient").map((patient) => (
           <li key={patient.id}>
             <Link to={`/patients/${patient.id}`}>{patient.id}</Link> (DOB:
-            <FhirValue type="date" value={patient.birthDate} />)
+            <FhirValue
+              type="date"
+              value={patient.birthDate}
+              options={{ dateStyle: "long" }}
+            />
+            , Gender:{" "}
+            <FhirValue
+              type="code"
+              value={patient.gender}
+              options={{
+                valueSetExpand: {
+                  url: "http://hl7.org/fhir/ValueSet/administrative-gender",
+                },
+              }}
+            />
+            )
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## What is this about

This PR add the option to expand a valueset automatically when using a `<FhirValue />` of type code.

It also adds the missing adapter types.

## Issue ticket numbers

N/A

## How can this be tested?

Ladle should contain enought examples.

## Known limitations/edge cases

The markdown implementation right now is not safe if you do not control the input.
I have created the following issue to track it: https://github.com/bonfhir/bonfhir/issues/100
