### PR TITLE
fix(core): :bug: fix token search builder when using only a system

### DIFF
--- a/packages/core/r4b/search-builder.test.ts
+++ b/packages/core/r4b/search-builder.test.ts
@@ -255,6 +255,10 @@ describe("search-builder", () => {
       "code:below=126851005",
     ],
     [
+      fhirSearch().token("code", { system: "http://hl7.org/fhir/sid/icd-10" }),
+      "code=http%3A%2F%2Fhl7.org%2Ffhir%2Fsid%2Ficd-10|",
+    ],
+    [
       fhirSearch().token(
         "code",
         "http://acme.org/fhir/ValueSet/cardiac-conditions",


### PR DESCRIPTION
## What is this about

This PR fixes an issue with `token` search when having a search with only the `system`.

## Issue ticket numbers

Fix #115

## How can this be tested?

Unit tests adjusted

## Known limitations/edge cases

N/A
