### PR TITLE
113-investigate-removing-fhirpath-dependency-from-core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,6 @@
     "@bonfhir/typescript-config": "^1.0.0",
     "@swc/core": "^1.3.24",
     "@swc/jest": "^0.2.24",
-    "@types/fhir": "^0.0.35",
     "@types/marked": "^4",
     "@types/node": "^18.11.18",
     "@types/rimraf": "^3",
@@ -37,7 +36,6 @@
   },
   "dependencies": {
     "@types/fhir": "^0.0.35",
-    "fhirpath": "^3.3.1",
     "marked": "^4.2.12"
   },
   "prettier": "@bonfhir/prettier-config"

--- a/packages/core/r4b/bundle-navigator.test.ts
+++ b/packages/core/r4b/bundle-navigator.test.ts
@@ -89,7 +89,7 @@ describe("BundleNavigator", () => {
       )[0]!.resource;
 
       const provenanceWithPatientTarget = navigator.revReference<Provenance>(
-        "ofType(Provenance).target.reference",
+        (provenance) => provenance.target,
         patientReference
       );
 
@@ -104,7 +104,7 @@ describe("BundleNavigator", () => {
       const patientReference = "Patient/23af4168-fc91-4b4d-a498-4485ce5ebc6f";
 
       const provenanceWithPatientTarget = navigator.revReference<Provenance>(
-        "ofType(Provenance).target.reference",
+        (provenance) => provenance.target,
         patientReference
       );
 
@@ -119,7 +119,7 @@ describe("BundleNavigator", () => {
         );
 
         const result = navigator.revReference<Provenance>(
-          "ofType(Provenance).target.reference",
+          (provenance) => provenance.target,
           patientReference
         );
 
@@ -142,7 +142,7 @@ describe("BundleNavigator", () => {
 
       const provenanceWithPatientTarget =
         navigator.firstRevReference<Provenance>(
-          "ofType(Provenance).target.reference",
+          (provenance) => provenance.target,
           patientReference
         );
 
@@ -156,7 +156,7 @@ describe("BundleNavigator", () => {
 
       const provenanceWithPatientTarget =
         navigator.firstRevReference<Provenance>(
-          "ofType(Provenance).target.reference",
+          (provenance) => provenance.target,
           patientReference
         );
 
@@ -171,7 +171,7 @@ describe("BundleNavigator", () => {
         );
 
         const result = navigator.firstRevReference<Provenance>(
-          "ofType(Provenance).target.reference",
+          (provenance) => provenance.target,
           patientReference
         );
 

--- a/packages/docs/packages/foundation/core.md
+++ b/packages/docs/packages/foundation/core.md
@@ -330,7 +330,7 @@ for (const patient of navigator.searchMatch()) {
     patient?.managingOrganization?.reference
   );
   const provenance = navigator.firstRevReference<Provenance>(
-    "ofType(Provenance).target.reference",
+    (provenance) => provenance.target,
     buildReferenceFromResource(patient).reference
   );
   const provenanceOrganization = navigator.reference(
@@ -344,7 +344,7 @@ In this example, the bundle is only iterated twice:
 - once to index the results for the calls to `searchMatch` and `reference`
 - a second time to create the on-the-fly index for the `firstRevReference`
 
-The reverse references uses [FHIR Path](http://hl7.org/fhirpath/N1/) to create indices that can be reused in loops.
+The reverse references also create indices that can be reused in loops, assuming the select function is the same (the cache key is the function `toString()` method).
 
 All indices are created lazily, so it is very cheap to create / return a `bundleNavigator` even if it is not used subsequently.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1959,7 +1959,6 @@ __metadata:
     "@types/node": ^18.11.18
     "@types/rimraf": ^3
     eslint: ^8.30.0
-    fhirpath: ^3.3.1
     jest: ^29.3.1
     jest-mock-extended: ^3.0.1
     marked: ^4.2.12


### PR DESCRIPTION
## What is this about

This PR removes the dependency on `fhirpath` for the `core` project.
It introduces a breaking change for the `bundleNavigator` that should easily be updated on consuming apps.

The net result of this change is 500KB shaved on the final app bundle, for a feature that may not be used at all by end apps.

## Issue ticket numbers

Fix #113

## How can this be tested?

Unit tests updated.

## Known limitations/edge cases

N/A
