### PR TITLE
fix(core): :adhesive_bandage: fix revReference signature to allow `null | undefined` on `select`

### DIFF
--- a/packages/core/r4b/bundle-navigator.ts
+++ b/packages/core/r4b/bundle-navigator.ts
@@ -124,7 +124,7 @@ export class BundleNavigator<
       | PrimaryResourceType
       | SecondaryResourceType
   >(
-    select: (resource: MatchType) => Reference | Reference[],
+    select: (resource: MatchType) => Reference | Reference[] | null | undefined,
     reference: string | null | undefined
   ): MatchType[] {
     if (!reference?.length) {
@@ -155,7 +155,7 @@ export class BundleNavigator<
       | PrimaryResourceType
       | SecondaryResourceType
   >(
-    select: (resource: MatchType) => Reference | Reference[],
+    select: (resource: MatchType) => Reference | Reference[] | null | undefined,
     reference: string | null | undefined
   ): MatchType | undefined {
     if (!reference?.length) {
@@ -224,12 +224,10 @@ export class BundleNavigator<
   /**
    * Return all unique resources across bundles.
    **/
-  public get resources(): IterableIterator<
-    PrimaryResourceType | SecondaryResourceType
-  > {
+  public get resources(): Array<PrimaryResourceType | SecondaryResourceType> {
     this._ensurePrimaryIndices();
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return this._resourcesByRelativeReference!.values();
+    return [...this._resourcesByRelativeReference!.values()];
   }
 
   private _ensurePrimaryIndices() {
@@ -276,7 +274,9 @@ export class BundleNavigator<
     }
   }
 
-  private _ensureSelectIndex(select: (res: unknown) => Reference): void {
+  private _ensureSelectIndex(
+    select: (res: unknown) => Reference | Reference[] | null | undefined
+  ): void {
     if (!this._resourcesByRefSelectIndex) {
       this._resourcesByRefSelectIndex = new Map();
     }
@@ -289,7 +289,7 @@ export class BundleNavigator<
             x.entry as BundleEntry<PrimaryResourceType | SecondaryResourceType>
         )
         .filter((x) => !!x) || []) {
-        for (const reference of asArray(select(entry.resource)).filter(
+        for (const reference of asArray(select(entry.resource) || []).filter(
           (ref) => !!ref?.reference
         )) {
           if (!mappedByReference.has(reference.reference)) {


### PR DESCRIPTION
## What is this about

This PR is a fix / improvement for the `revReference` feature to allow null | undefined `select` returned value.
It is easier to use this way in real-life scenario.

## Issue ticket numbers

N/A

## How can this be tested?

N/A

## Known limitations/edge cases

N/A