### PR TITLE
fix(fhir-query): :adhesive_bandage: fix error when search cache is null

### DIFF
--- a/packages/fhir-query/r4b/fhir-query-hooks.tsx
+++ b/packages/fhir-query/r4b/fhir-query-hooks.tsx
@@ -92,27 +92,21 @@ export const FhirQueryKeys = {
     try {
       const inSearch = (queryClient.getQueriesData([type, "search"]) || [])
         .flatMap(([, result]) =>
-          (result as BundleResult<FhirResource>).nav.type(type)
+          (result as BundleResult<FhirResource>)?.nav?.type(type)
         )
-        .find((resource) => resource.id === id);
+        .find((resource) => resource?.id === id);
       if (inSearch) {
         return inSearch;
       }
 
       return (
-        (
-          queryClient.getQueriesData<{
-            pages: Array<BundleResult<FhirResource>>;
-          }>([type, "infiniteSearch"]) || []
-        )
-          .flatMap(([, pages]) => pages?.pages || [])
-          .flatMap((data: BundleResult<FhirResource>) => data.nav.type(type))
-          // We have a typing bug here with lodash - thus this horrible construct for any.
-          .find(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            ((resource: FhirResource) => resource.id === id) as any
-          ) as unknown as ExtractResource<ResourceType> | undefined
-      );
+        queryClient.getQueriesData<{
+          pages: Array<BundleResult<FhirResource>>;
+        }>([type, "infiniteSearch"]) || []
+      )
+        .flatMap(([, pages]) => pages?.pages || [])
+        .flatMap((data: BundleResult<FhirResource>) => data?.nav?.type(type))
+        .find((resource: FhirResource) => resource?.id === id);
     } catch (error) {
       // Just in case the cache is corrupted.
       console.error(error);


### PR DESCRIPTION
## What is this about

This PR addresses a small error message than popup in browser when the search cache is null (because the query is disabled or unexecuted, for example).

## Issue ticket numbers

Fix #145

## How can this be tested?

N/A

## Known limitations/edge cases

N/A