### PR TITLE
Date/time formatter: add relative option

### DIFF
--- a/packages/core/r4b/data-types/date.test.ts
+++ b/packages/core/r4b/data-types/date.test.ts
@@ -52,6 +52,74 @@ describe("fhirDateTypeAdapter", () => {
           ["2023-02-08", { dateStyle: "full" }, "Wednesday, February 8, 2023"],
           ["2023-02-08", { dateStyle: "medium" }, "Feb 8, 2023"],
           ["2023-02-08", { dateStyle: "short" }, "2/8/23"],
+          [
+            "2023-02-08",
+            {
+              dateStyle: "relative",
+              relativeTo: "2023-02-08",
+            },
+            "today",
+          ],
+          [
+            "2023-02-08",
+            { dateStyle: "relative", relativeTo: "2023-02-09" },
+            "yesterday",
+          ],
+          [
+            "2023-02-08",
+            { dateStyle: "relative", relativeTo: "2023-02-12" },
+            "4 days ago",
+          ],
+          [
+            "2023-02-08",
+            { dateStyle: "relative", relativeTo: "2023-03-09" },
+            "last month",
+          ],
+          [
+            "2023-02-08",
+            { dateStyle: "relative", relativeTo: "2023-04-08" },
+            "2 months ago",
+          ],
+          [
+            "2023-02-08",
+            { dateStyle: "relative", relativeTo: "2023-12-31" },
+            "last year",
+          ],
+          [
+            "2023-02-08",
+            { dateStyle: "relative", relativeTo: "2025-12-31" },
+            "2 years ago",
+          ],
+          [
+            "2023-02-08",
+            { dateStyle: "relative", relativeTo: "2023-02-07" },
+            "tomorrow",
+          ],
+          [
+            "2023-02-08",
+            { dateStyle: "relative", relativeTo: "2023-02-04" },
+            "in 4 days",
+          ],
+          [
+            "2023-02-08",
+            { dateStyle: "relative", relativeTo: "2023-01-09" },
+            "next month",
+          ],
+          [
+            "2023-02-08",
+            { dateStyle: "relative", relativeTo: "2022-12-01" },
+            "in 2 months",
+          ],
+          [
+            "2023-02-08",
+            { dateStyle: "relative", relativeTo: "2022-03-01" },
+            "next year",
+          ],
+          [
+            "2023-02-08",
+            { dateStyle: "relative", relativeTo: "2020-12-31" },
+            "in 3 years",
+          ],
           ["2023-02", { dateStyle: "medium" }, "Feb 2023"],
           ["2023", undefined, "2023"],
         ])("format %p", (value, style, expected) => {
@@ -72,6 +140,19 @@ describe("fhirDateTypeAdapter", () => {
         ["2023-02-08", { dateStyle: "full" }, "mercredi 8 février 2023"],
         ["2023-02-08", { dateStyle: "medium" }, "8 févr. 2023"],
         ["2023-02-08", { dateStyle: "short" }, "2023-02-08"],
+        [
+          "2023-02-08",
+          {
+            dateStyle: "relative",
+            relativeTo: "2023-02-08",
+          },
+          "aujourd’hui",
+        ],
+        [
+          "2023-02-08",
+          { dateStyle: "relative", relativeTo: "2023-02-09" },
+          "hier",
+        ],
         ["2023-02", { dateStyle: "medium" }, "févr. 2023"],
         ["2023", undefined, "2023"],
       ])("format %p", (value, style, expected) => {

--- a/packages/core/r4b/data-types/date.ts
+++ b/packages/core/r4b/data-types/date.ts
@@ -1,4 +1,5 @@
 import { FhirDataTypeAdapter } from "../data-type-adapter";
+import { utcNow } from "../date";
 import { fhirDateRegexpFragment } from "./helpers/dateTimeRegexp";
 
 /**
@@ -7,9 +8,16 @@ import { fhirDateRegexpFragment } from "./helpers/dateTimeRegexp";
  * @see https://hl7.org/fhir/datatypes.html#date
  */
 
-export interface FhirDateFormatOptions {
-  dateStyle?: "full" | "long" | "medium" | "short" | null | undefined;
-}
+export type FhirDateFormatOptions =
+  | {
+      dateStyle?: "full" | "long" | "medium" | "short" | null | undefined;
+    }
+  | {
+      dateStyle: "relative";
+      relativeStyle?: "long" | "short" | null | undefined;
+      /** From when the relative computation happen - defaults to now. */
+      relativeTo?: string | number | Date | null | undefined;
+    };
 
 export interface FhirDateTypeAdapter {
   locale?: FhirDataTypeAdapter["locale"];
@@ -125,6 +133,14 @@ export function fhirDateTypeAdapter(
           intlOptions.month = convertDateStyleToMonthStyle(options?.dateStyle);
           break;
         case "full":
+          if (options?.dateStyle === "relative") {
+            return formatRelativeDate(
+              locale,
+              fhirDate.date,
+              options.relativeTo,
+              options.relativeStyle
+            );
+          }
           intlOptions.dateStyle = options?.dateStyle || undefined;
           break;
         default:
@@ -150,4 +166,69 @@ function convertDateStyleToMonthStyle(
     default:
       return undefined;
   }
+}
+
+/**
+ * @see https://momentjs.com/docs/#/displaying/fromnow/
+ * @see https://momentjs.com/docs/#/displaying/tonow/
+ */
+function formatRelativeDate(
+  locale: string | undefined,
+  value: Date,
+  relativeTo: string | number | Date | null | undefined,
+  relativeStyle: "long" | "short" | null | undefined
+) {
+  const relativeToDate = relativeTo ? new Date(relativeTo) : utcNow();
+  const relative = new Intl.RelativeTimeFormat(locale, {
+    style: relativeStyle ?? undefined,
+    numeric: "auto",
+  });
+
+  if (
+    value.getFullYear() === relativeToDate.getFullYear() &&
+    value.getMonth() === relativeToDate.getMonth() &&
+    value.getDate() === relativeToDate.getDate()
+  ) {
+    return relative.format(0, "day");
+  }
+
+  const diffSec = Math.floor(
+    (relativeToDate.getTime() - value.getTime()) / 1000
+  );
+
+  // from now
+  if (diffSec >= 0) {
+    if (diffSec < 126000) {
+      return relative.format(-1, "day");
+    } else if (diffSec < 2160000) {
+      return relative.format(-Math.floor(diffSec / 86400), "days");
+    } else if (diffSec < 3888000) {
+      return relative.format(-1, "month");
+    } else if (diffSec < 27561600) {
+      const monthDiff = relativeToDate.getMonth() - value.getMonth();
+      const yearDiff = relativeToDate.getFullYear() - value.getFullYear();
+      return relative.format(-(monthDiff + yearDiff * 12), "months");
+    } else if (diffSec < 47260800) {
+      return relative.format(-1, "year");
+    }
+
+    return relative.format(-Math.floor(diffSec / 31104000), "years");
+  }
+
+  // in now
+  if (diffSec > -126000) {
+    return relative.format(1, "day");
+  } else if (diffSec > -2160000) {
+    return relative.format(-Math.floor(diffSec / 86400), "days");
+  } else if (diffSec > -3888000) {
+    return relative.format(1, "month");
+  } else if (diffSec > -27561600) {
+    const monthDiff = relativeToDate.getMonth() - value.getMonth();
+    const yearDiff = relativeToDate.getFullYear() - value.getFullYear();
+    return relative.format(-(monthDiff + yearDiff * 12), "months");
+  } else if (diffSec > -47260800) {
+    return relative.format(1, "year");
+  }
+
+  return relative.format(-Math.floor(diffSec / 31104000), "years");
 }

--- a/packages/core/r4b/data-types/dateTime.test.ts
+++ b/packages/core/r4b/data-types/dateTime.test.ts
@@ -120,6 +120,11 @@ describe("fhirDateTimeTypeAdapter", () => {
       ["2023-02-08", { dateStyle: "full" }, "Wednesday, February 8, 2023"],
       ["2023-02-08", { dateStyle: "medium" }, "Feb 8, 2023"],
       ["2023-02-08", { dateStyle: "short" }, "2/8/23"],
+      [
+        "2023-02-08",
+        { dateStyle: "relative", relativeTo: "2023-02-09" },
+        "yesterday",
+      ],
       ["2023-02", { dateStyle: "medium" }, "Feb 2023"],
       [
         "2015-02-07T13:28:17-05:00",
@@ -146,6 +151,41 @@ describe("fhirDateTimeTypeAdapter", () => {
         "2015-02-07T13:28:17-05:00",
         { dateStyle: "full" },
         "Saturday, February 7, 2015 at 6:28 PM",
+      ],
+      [
+        "2015-02-07T13:28:17-05:00",
+        { dateStyle: "relative", relativeTo: "2015-02-07T13:28:17-05:00" },
+        "now",
+      ],
+      [
+        "2015-02-07T13:28:17-05:00",
+        { dateStyle: "relative", relativeTo: "2015-02-07T13:28:20-05:00" },
+        "3 seconds ago",
+      ],
+      [
+        "2015-02-07T13:28:17-05:00",
+        { dateStyle: "relative", relativeTo: "2015-02-07T13:29:20-05:00" },
+        "1 minute ago",
+      ],
+      [
+        "2015-02-07T13:28:17-05:00",
+        { dateStyle: "relative", relativeTo: "2015-02-07T14:29:20-05:00" },
+        "1 hour ago",
+      ],
+      [
+        "2015-02-07T13:28:17-05:00",
+        { dateStyle: "relative", relativeTo: "2015-02-08T14:29:20Z" },
+        "20 hours ago",
+      ],
+      [
+        "2015-02-07T13:28:17-05:00",
+        { dateStyle: "relative", relativeTo: "2015-02-07T13:25:20-05:00" },
+        "in 3 minutes",
+      ],
+      [
+        "2015-02-07T13:28:17-05:00",
+        { dateStyle: "relative", relativeTo: "2015-02-07T10:25:20-05:00" },
+        "in 4 hours",
       ],
     ])("format %p %p", (value, style, expected) => {
       expect(adapter.format(value, style)).toEqual(expected);

--- a/packages/core/r4b/data-types/helpers/index.ts
+++ b/packages/core/r4b/data-types/helpers/index.ts
@@ -2,6 +2,7 @@ export const removeDoubleSpaces = (value: string): string =>
   value.replace(/\s{2,}/g, " ").trim();
 
 import { Period } from "fhir/r4";
+import { utcNow } from "../../date";
 import { FhirDateTimeTypeAdapter, fhirDateTimeTypeAdapter } from "../dateTime";
 
 let dateTimeAdapter: FhirDateTimeTypeAdapter;
@@ -27,3 +28,90 @@ export const comparePeriods = (
 
   return 0;
 };
+
+/**
+ * @see https://momentjs.com/docs/#/displaying/fromnow/
+ * @see https://momentjs.com/docs/#/displaying/tonow/
+ */
+export function formatRelativeDateTime(
+  locale: string | undefined,
+  value: Date,
+  relativeTo: string | number | Date | null | undefined,
+  relativeStyle: "long" | "short" | null | undefined,
+  dateOnlyMode = false
+) {
+  const relativeToDate = relativeTo ? new Date(relativeTo) : utcNow();
+  const relative = new Intl.RelativeTimeFormat(locale, {
+    style: relativeStyle ?? undefined,
+    numeric: "auto",
+  });
+
+  if (
+    dateOnlyMode &&
+    value.getFullYear() === relativeToDate.getFullYear() &&
+    value.getMonth() === relativeToDate.getMonth() &&
+    value.getDate() === relativeToDate.getDate()
+  ) {
+    return relative.format(0, "day");
+  }
+
+  const diffSec = Math.floor(
+    (relativeToDate.getTime() - value.getTime()) / 1000
+  );
+
+  // from now
+  if (diffSec >= 0) {
+    if (diffSec < 44) {
+      return relative.format(-diffSec, "seconds");
+    } else if (diffSec < 89) {
+      return relative.format(-1, "minute");
+    } else if (diffSec < 2640) {
+      return relative.format(-Math.floor(diffSec / 60), "minutes");
+    } else if (diffSec < 5340) {
+      return relative.format(-1, "hour");
+    } else if (diffSec < 75600) {
+      return relative.format(-Math.floor(diffSec / 3600), "hours");
+    } else if (diffSec < 126000) {
+      return relative.format(-1, "day");
+    } else if (diffSec < 2160000) {
+      return relative.format(-Math.floor(diffSec / 86400), "days");
+    } else if (diffSec < 3888000) {
+      return relative.format(-1, "month");
+    } else if (diffSec < 27561600) {
+      const monthDiff = relativeToDate.getMonth() - value.getMonth();
+      const yearDiff = relativeToDate.getFullYear() - value.getFullYear();
+      return relative.format(-(monthDiff + yearDiff * 12), "months");
+    } else if (diffSec < 47260800) {
+      return relative.format(-1, "year");
+    }
+
+    return relative.format(-Math.floor(diffSec / 31104000), "years");
+  }
+
+  // in now
+  if (diffSec > -44) {
+    return relative.format(-diffSec, "seconds");
+  } else if (diffSec > -89) {
+    return relative.format(-1, "minute");
+  } else if (diffSec > -2640) {
+    return relative.format(-Math.floor(diffSec / 60), "minutes");
+  } else if (diffSec > -5340) {
+    return relative.format(-1, "hour");
+  } else if (diffSec > -75600) {
+    return relative.format(-Math.floor(diffSec / 3600), "hours");
+  } else if (diffSec > -126000) {
+    return relative.format(1, "day");
+  } else if (diffSec > -2160000) {
+    return relative.format(-Math.floor(diffSec / 86400), "days");
+  } else if (diffSec > -3888000) {
+    return relative.format(1, "month");
+  } else if (diffSec > -27561600) {
+    const monthDiff = relativeToDate.getMonth() - value.getMonth();
+    const yearDiff = relativeToDate.getFullYear() - value.getFullYear();
+    return relative.format(-(monthDiff + yearDiff * 12), "months");
+  } else if (diffSec > -47260800) {
+    return relative.format(1, "year");
+  }
+
+  return relative.format(-Math.floor(diffSec / 31104000), "years");
+}

--- a/packages/core/r4b/data-types/instant.test.ts
+++ b/packages/core/r4b/data-types/instant.test.ts
@@ -88,6 +88,11 @@ describe("fhirInstantTypeAdapter", () => {
         { dateStyle: "full" },
         "Saturday, February 7, 2015 at 6:28 PM",
       ],
+      [
+        "2015-02-07T13:28:17-05:00",
+        { dateStyle: "relative", relativeTo: "2015-02-07T13:28:20-05:00" },
+        "3 seconds ago",
+      ],
     ])("format %p %p", (value, style, expected) => {
       expect(adapter.format(value, style)).toEqual(expected);
     });

--- a/packages/core/r4b/data-types/instant.ts
+++ b/packages/core/r4b/data-types/instant.ts
@@ -1,4 +1,5 @@
 import { FhirDataTypeAdapter } from "../data-type-adapter";
+import { formatRelativeDateTime } from "./helpers";
 import {
   fhirDateRegexpFragment,
   fhirTimeWithZoneRegexpFragment,
@@ -10,10 +11,17 @@ import {
  * @see https://hl7.org/fhir/datatypes.html#instant
  */
 
-export interface FhirInstantFormatOptions {
-  dateStyle?: "full" | "long" | "medium" | "short" | null;
-  timeStyle?: "full" | "long" | "medium" | "short" | null;
-}
+export type FhirInstantFormatOptions =
+  | {
+      dateStyle?: "full" | "long" | "medium" | "short" | null;
+      timeStyle?: "full" | "long" | "medium" | "short" | null;
+    }
+  | {
+      dateStyle: "relative";
+      relativeStyle?: "long" | "short" | null | undefined;
+      /** From when the relative computation happen - defaults to now. */
+      relativeTo?: string | number | Date | null | undefined;
+    };
 
 export interface FhirInstantTypeAdapter {
   locale?: FhirDataTypeAdapter["locale"];
@@ -81,11 +89,20 @@ export function fhirInstantTypeAdapter(
 
       const intlOptions: Intl.DateTimeFormatOptions = {};
 
+      if (options?.dateStyle === "relative") {
+        return formatRelativeDateTime(
+          locale,
+          fhirInstant,
+          options.relativeTo,
+          options.relativeStyle
+        );
+      }
+
       // by default we always show the date
-      intlOptions.dateStyle =
-        typeof options?.dateStyle === "undefined"
-          ? "short"
-          : options.dateStyle || undefined;
+      intlOptions.dateStyle = options?.dateStyle ?? "short";
+      typeof options?.dateStyle === "undefined"
+        ? "short"
+        : options?.dateStyle || undefined;
       // by default we always show the time
       intlOptions.timeStyle =
         typeof options?.timeStyle === "undefined"

--- a/packages/docs/packages/foundation/core.md
+++ b/packages/docs/packages/foundation/core.md
@@ -386,6 +386,8 @@ adapter.date.format("2023-12-31", { dateStyle: "full" });
 // "Wednesday, February 8, 2023"
 adapter.date.format("2023-12-31", { dateStyle: "medium" });
 // "Feb 8, 2023"
+adapter.date.format("2023-12-31", { dateStyle: "relative" });
+// "3 days ago"
 
 const zhAdapter = intlFhirDataTypeAdapter("zh-Hans-CN-u-nu-hanidec");
 adapter.decimal.format("123456.78900");

--- a/samples/ehr-sample-app/src/pages/patients/Patients.tsx
+++ b/samples/ehr-sample-app/src/pages/patients/Patients.tsx
@@ -7,9 +7,7 @@ import { Link } from "react-router-dom";
 import { Page } from "../../components/Page";
 
 export function Patients(): ReactElement | null {
-  const patientsQuery = useFhirSearch("Patient", (search) =>
-    search.active("true")
-  );
+  const patientsQuery = useFhirSearch("Patient", (search) => search);
 
   if (patientsQuery.isInitialLoading) {
     return <div>Loading...</div>;
@@ -17,7 +15,14 @@ export function Patients(): ReactElement | null {
 
   return (
     <Page>
-      <Typography.Title>Patients</Typography.Title>
+      <Typography.Title>
+        Patients{" "}
+        <FhirValue
+          type="dateTime"
+          value="2023-03-10T07:49:00-05:00"
+          options={{ dateStyle: "relative" }}
+        />
+      </Typography.Title>
       <ul>
         {patientsQuery.data?.nav.type("Patient").map((patient) => (
           <li key={patient.id}>
@@ -25,7 +30,7 @@ export function Patients(): ReactElement | null {
             <FhirValue
               type="date"
               value={patient.birthDate}
-              options={{ dateStyle: "long" }}
+              options={{ dateStyle: "relative" }}
             />
             , Gender:{" "}
             <FhirValue


### PR DESCRIPTION
## What is this about

This PR adds a "relative" option to date/time formatters, to display relative time info (e.g., "a day ago", "in 3 minutes", ...).

It also adds an option to `<FhirValue />` to auto-refresh when using a relative date/time formatting option.

Implementation uses [`Intl.RelativeTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat), and the cut-offs parameters are inspired by Moment.js [`fromNow`](https://momentjs.com/docs/#/displaying/fromnow/) and [`toNow`](https://momentjs.com/docs/#/displaying/tonow/).

## Issue ticket numbers

Fix #133

## How can this be tested?

Automated tests updated.

## Known limitations/edge cases

N/A
