### PR TITLE
docs(docs): :memo: add links to Change Logs

### DIFF
--- a/packages/docs/packages/clinical/charlson-comorbidity-index.md
+++ b/packages/docs/packages/clinical/charlson-comorbidity-index.md
@@ -19,6 +19,8 @@ In order to make it work, you must provide such a mapping, that needs to be revi
 An _example_ of [such mapping using ICD10 codes can be seen here](https://github.com/bonfhir/bonfhir/blob/main/packages/charlson-comorbidity-index/r4b/__fixtures__/icd10-codes-conceptmap.fhir.json).<br/>
 We make absolutely no claim that this is accurate or up-to-date, so you MUST make and review your own mapping.**
 
+_[Change Log](https://github.com/bonfhir/bonfhir/blob/main/packages/charlson-comorbidity-index/CHANGELOG.md)_
+
 ```typescript
 import {
   buildTemplateConceptMapForCCI,

--- a/packages/docs/packages/foundation/codegen.md
+++ b/packages/docs/packages/foundation/codegen.md
@@ -13,3 +13,5 @@ npm install @bonfhir/codegen
 This package provides a CLI that can assist in generating source code using [FHIR definition files](https://hl7.org/fhir/downloads.html).
 
 See the [Code generation section](/contributing/codegen) in contributing for more information.
+
+_[Change Log](https://github.com/bonfhir/bonfhir/blob/main/packages/codegen/CHANGELOG.md)_

--- a/packages/docs/packages/foundation/core.md
+++ b/packages/docs/packages/foundation/core.md
@@ -13,6 +13,8 @@ npm install @bonfhir/core
 The `core` package provides utilities to easily manipulate FHIR resources.
 It is also used as a common dependency for all other packages to rely on.
 
+_[Change Log](https://github.com/bonfhir/bonfhir/blob/main/packages/core/CHANGELOG.md)_
+
 ## Builders & narrative generators
 
 As specified in the [FHIR `Narrative` description](https://hl7.org/fhir/narrative.html):

--- a/packages/docs/packages/foundation/terminology.md
+++ b/packages/docs/packages/foundation/terminology.md
@@ -18,6 +18,8 @@ terminology appropriately.
 Nevertheless, this library provides some out-of-the-box typings for the common [`ValueSets`](https://hl7.org/fhir/terminologies-valuesets.html)
 defined in the FHIR spec.
 
+_[Change Log](https://github.com/bonfhir/bonfhir/blob/main/packages/terminology/CHANGELOG.md)_
+
 ## ValueSet expansion
 
 For a lot of the [`ValueSet` defined in the FHIR Terminology](https://hl7.org/fhir/terminologies-valuesets.html), this provide

--- a/packages/docs/packages/foundation/test-support.md
+++ b/packages/docs/packages/foundation/test-support.md
@@ -12,6 +12,8 @@ npm install @bonfhir/test-support
 
 The `test-support` package is dedicated to resources that are useful in the context of automated tests and/or data generation.
 
+_[Change Log](https://github.com/bonfhir/bonfhir/blob/main/packages/test-support/CHANGELOG.md)_
+
 ## Fakes
 
 It is sometime useful to be able to generate random resources with somewhat plausible data.

--- a/packages/docs/packages/integrations/cmsdotgov.md
+++ b/packages/docs/packages/integrations/cmsdotgov.md
@@ -12,6 +12,8 @@ npm install @bonfhir/cmsdotgov
 
 This package regroups features related to the [CMS.gov](https://www.cms.gov/) products & features.
 
+_[Change Log](https://github.com/bonfhir/bonfhir/blob/main/packages/cmsdotgov/CHANGELOG.md)_
+
 ## NPPES / NPI Registry
 
 Provides a utility to retrieve information from the [National Plan and Provider Enumeration System (NPPES) National Provider Identifier (NPI) registry](https://npiregistry.cms.hhs.gov/).

--- a/packages/docs/packages/integrations/medplum.md
+++ b/packages/docs/packages/integrations/medplum.md
@@ -12,6 +12,8 @@ npm install @bonfhir/medplum
 
 This package simply contains an adapter from the [Medplum Client](https://www.medplum.com/docs/sdk/classes/MedplumClient) to the [`FhirRestfulClient` interface present in the `core` package.](/packages/foundation/core#fhir-client-interface)
 
+_[Change Log](https://github.com/bonfhir/bonfhir/blob/main/packages/medplum/CHANGELOG.md)_
+
 ```typescript
 import { buildFhirRestfulClientAdapter } from "@bonfhir/medplum/r4b";
 import { MedplumClient } from "@medplum/core";

--- a/packages/docs/packages/integrations/nih-nlm.md
+++ b/packages/docs/packages/integrations/nih-nlm.md
@@ -12,6 +12,8 @@ npm install @bonfhir/nih-nlm
 
 This package regroups features related to the [NIH National Library of Medicine](https://www.nlm.nih.gov/) products & features.
 
+_[Change Log](https://github.com/bonfhir/bonfhir/blob/main/packages/nih-nlm/CHANGELOG.md)_
+
 ## RxNorm
 
 Provides a utility to retrieve information from the [RXNorm API](https://lhncbc.nlm.nih.gov/RxNav/APIs/RxNormAPIs.html).

--- a/packages/docs/packages/ui/fhir-query.md
+++ b/packages/docs/packages/ui/fhir-query.md
@@ -15,6 +15,8 @@ a [React / React Native](https://reactjs.org/) application.
 
 It is based on [TanStack React Query](https://tanstack.com/query/latest).
 
+_[Change Log](https://github.com/bonfhir/bonfhir/blob/main/packages/fhir-query/CHANGELOG.md)_
+
 ## Getting started
 
 _We **strongly** advise that you start by familiarizing yourself with [React Query](https://tanstack.com/query/latest)

--- a/packages/docs/packages/ui/ui-components.md
+++ b/packages/docs/packages/ui/ui-components.md
@@ -12,4 +12,6 @@ npm install @bonfhir/ui-components
 
 TBD.
 
+_[Change Log](https://github.com/bonfhir/bonfhir/blob/main/packages/ui-components/CHANGELOG.md)_
+
 [View the ladle (Storybook) here](pathname:///ui-components/dist-ladle/index.html)


### PR DESCRIPTION
## What is this about

This PR simply add links to package Change Logs in the documentation.

## Issue ticket numbers

N/A

## How can this be tested?

N/A

## Known limitations/edge cases

N/A