### PR TITLE
docs(docs): :memo: add Algolia search engine

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -127,6 +127,11 @@ const config = {
       prism: {
         theme: lightCodeTheme,
       },
+      algolia: {
+        appId: "C444QI5SK7",
+        apiKey: "fc7d73ded65b514d4e2773653bc196c4",
+        indexName: "bonfhir",
+      },
     }),
 };
 


### PR DESCRIPTION
## What is this about

This PR adds search to the documentation using [Algolia Search](https://docusaurus.io/docs/search#using-algolia-docsearch).
Current algolia account is tied to my Google julien@alleycorpnord.com. API Keys are in 1Password.

## Issue ticket numbers

Fix #159

## How can this be tested?

Launch the docs and start searching.

## Known limitations/edge cases

N/A
