### PR TITLE
fix: :white_check_mark: fix failing unit tests on node 18.15.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/devcontainers/typescript-node:0-18-bullseye
 
+# Let's make sure to use a supported version of node
+RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install 18.15.0 && nvm use 18.15.0"
+
 # Default ZSH configuration only load the git plugin. This adds yarn as well.
 RUN su node -c "sed -i 's/plugins=(git)/plugins=(git yarn)/' ~/.zshrc"
 

--- a/packages/core/r4b/data-types/dateTime.test.ts
+++ b/packages/core/r4b/data-types/dateTime.test.ts
@@ -25,7 +25,7 @@ describe("fhirDateTimeTypeAdapter", () => {
         });
 
         expect(adapter.format("2015-02-07T13:28:17+05:00")).toEqual(
-          "2/7/15, 8:28 AM"
+          "2/7/15, 8:28 AM"
         );
       });
     });
@@ -129,28 +129,28 @@ describe("fhirDateTimeTypeAdapter", () => {
       [
         "2015-02-07T13:28:17-05:00",
         { dateStyle: "long", timeStyle: "medium" },
-        "February 7, 2015 at 6:28:17 PM",
+        "February 7, 2015 at 6:28:17 PM",
       ],
       [
         "2015-02-07T13:28:17-05:00",
         { dateStyle: "medium", timeStyle: "long" },
-        "Feb 7, 2015, 6:28:17 PM UTC",
+        "Feb 7, 2015, 6:28:17 PM UTC",
       ],
       [
         "2015-02-07T13:28:17-05:00",
         { dateStyle: "medium", timeStyle: "medium" },
-        "Feb 7, 2015, 6:28:17 PM",
+        "Feb 7, 2015, 6:28:17 PM",
       ],
-      ["2015-02-07T13:28:17-05:00", undefined, "2/7/15, 6:28 PM"],
+      ["2015-02-07T13:28:17-05:00", undefined, "2/7/15, 6:28 PM"],
       [
         "2015-02-07T13:28:17-05:00",
         { timeStyle: "full" },
-        "2/7/15, 6:28:17 PM Coordinated Universal Time",
+        "2/7/15, 6:28:17 PM Coordinated Universal Time",
       ],
       [
         "2015-02-07T13:28:17-05:00",
         { dateStyle: "full" },
-        "Saturday, February 7, 2015 at 6:28 PM",
+        "Saturday, February 7, 2015 at 6:28 PM",
       ],
       [
         "2015-02-07T13:28:17-05:00",

--- a/packages/core/r4b/data-types/instant.test.ts
+++ b/packages/core/r4b/data-types/instant.test.ts
@@ -20,7 +20,7 @@ describe("fhirInstantTypeAdapter", () => {
         );
 
         expect(adapter.format("2015-02-07T13:28:17+05:00")).toEqual(
-          "2/7/15, 8:28 AM"
+          "2/7/15, 8:28 AM"
         );
       });
     });
@@ -65,28 +65,28 @@ describe("fhirInstantTypeAdapter", () => {
       [
         "2015-02-07T13:28:17-05:00",
         { dateStyle: "long", timeStyle: "medium" },
-        "February 7, 2015 at 6:28:17 PM",
+        "February 7, 2015 at 6:28:17 PM",
       ],
       [
         "2015-02-07T13:28:17-05:00",
         { dateStyle: "medium", timeStyle: "long" },
-        "Feb 7, 2015, 6:28:17 PM UTC",
+        "Feb 7, 2015, 6:28:17 PM UTC",
       ],
       [
         "2015-02-07T13:28:17-05:00",
         { dateStyle: "medium", timeStyle: "medium" },
-        "Feb 7, 2015, 6:28:17 PM",
+        "Feb 7, 2015, 6:28:17 PM",
       ],
-      ["2015-02-07T13:28:17-05:00", undefined, "2/7/15, 6:28 PM"],
+      ["2015-02-07T13:28:17-05:00", undefined, "2/7/15, 6:28 PM"],
       [
         "2015-02-07T13:28:17-05:00",
         { timeStyle: "full" },
-        "2/7/15, 6:28:17 PM Coordinated Universal Time",
+        "2/7/15, 6:28:17 PM Coordinated Universal Time",
       ],
       [
         "2015-02-07T13:28:17-05:00",
         { dateStyle: "full" },
-        "Saturday, February 7, 2015 at 6:28 PM",
+        "Saturday, February 7, 2015 at 6:28 PM",
       ],
       [
         "2015-02-07T13:28:17-05:00",

--- a/packages/core/r4b/data-types/period.test.ts
+++ b/packages/core/r4b/data-types/period.test.ts
@@ -37,7 +37,7 @@ describe("fhirPeriodTypeAdapter", () => {
           dateStyle: "short",
           timeStyle: "long",
         },
-        "2/7/15, 6:28:17 PM UTC - 2/8/15, 6:28:17 PM UTC",
+        "2/7/15, 6:28:17 PM UTC - 2/8/15, 6:28:17 PM UTC",
       ],
     ])("parse %p", (value, options, expected) => {
       expect(adapter.format(value, options)).toEqual(expected);

--- a/packages/core/r4b/data-types/time.test.ts
+++ b/packages/core/r4b/data-types/time.test.ts
@@ -17,14 +17,14 @@ describe("fhirTimeTypeAdapter", () => {
         it.each(<
           Array<[string | FhirTime, FhirTimeFormatOptions | undefined, string]>
         >[
-          ["18:30:25.123", undefined, "6:30 PM"],
+          ["18:30:25.123", undefined, "6:30 PM"],
           [
             "18:30:25.123",
             { timeStyle: "full" },
-            "6:30:25 PM Coordinated Universal Time",
+            "6:30:25 PM Coordinated Universal Time",
           ],
-          ["18:30:25.123", { timeStyle: "short" }, "6:30 PM"],
-          ["18:30:25", { timeStyle: "medium" }, "6:30:25 PM"],
+          ["18:30:25.123", { timeStyle: "short" }, "6:30 PM"],
+          ["18:30:25", { timeStyle: "medium" }, "6:30:25 PM"],
         ])("format %p", (value, style, expected) => {
           expect(adapter.format(value, style)).toEqual(expected);
         });


### PR DESCRIPTION
## What is this about

Apparently, there has been a change in 18.15.0 on the character output by the Intl API.
Previously, there used to be a different space character on some time formatting situations.

## Issue ticket numbers

N/A

## How can this be tested?

Run the unit tests.

## Known limitations/edge cases

N/A
