### PR TITLE
chore(core): :package: embed dependencies in the build

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,7 @@
   "license": "APACHE-2.0",
   "type": "module",
   "scripts": {
-    "build": "yarn clean && tsup r4b/index.ts --format esm,cjs --out-dir dist/r4b --shims --dts --tsconfig tsconfig.build.json",
+    "build": "yarn clean && tsup",
     "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
     "clean": "rimraf dist/",
     "codegen": "yarn workspace @bonfhir/codegen run dev run -d \"${PWD}/../../fhir/r4b/definitions/**/*.json\" -t \"${PWD}/r4b/**/*.hbs\" --helpers \"${PWD}/template-helpers.js\" -p 'prettier --write %files%'",
@@ -28,15 +28,15 @@
     "eslint": "^8.36.0",
     "jest": "^29.5.0",
     "jest-mock-extended": "^3.0.3",
+    "localized-address-format": "^1.3.0",
+    "marked": "^4.2.12",
     "prettier": "^2.8.4",
     "rimraf": "^4.4.0",
     "tsup": "^6.6.3",
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@types/fhir": "^0.0.35",
-    "localized-address-format": "^1.3.0",
-    "marked": "^4.2.12"
+    "@types/fhir": "^0.0.35"
   },
   "prettier": "@bonfhir/prettier-config"
 }

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["r4b/index.ts"],
+  format: ["esm", "cjs"],
+  outDir: "dist/r4b",
+  shims: true,
+  dts: true,
+  tsconfig: "tsconfig.build.json",
+  noExternal: ["localized-address-format", "marked"],
+});


### PR DESCRIPTION
## What is this about

This PR update the `core` build system to embed both `localized-address-format` and `marked` dependencies in the bundle, thus removing it as an app dependency.
This allows `core` to only have `@types/fhir` as a dependency.

## Issue ticket numbers

N/A

## How can this be tested?

Should have 0 impact.

## Known limitations/edge cases

N/A