### PR TITLE
167-expose-resourcesearch-builder-directly-in-the-client-interface

### DIFF
--- a/packages/cmsdotgov/r4b/nppes/npiregistry-sync.ts
+++ b/packages/cmsdotgov/r4b/nppes/npiregistry-sync.ts
@@ -5,7 +5,6 @@ import {
   buildReferenceFromResource,
   createOr,
   FhirRestfulClient,
-  resourceSearch,
   uniqBy,
   utcNow,
 } from "@bonfhir/core/r4b";
@@ -288,12 +287,13 @@ export class NPIRegistrySyncSession {
                     : undefined,
               })
             ),
-            resourceSearch("HealthcareService")
-              .organization({ type: "Organization", id: result.id! })
-              .servicecategory({
-                system: "https://npidb.org/taxonomy",
-                code: taxonomy.code,
-              }).href
+            (search) =>
+              search
+                .organization({ type: "Organization", id: result!.id! })
+                .servicecategory({
+                  system: "https://npidb.org/taxonomy",
+                  code: taxonomy.code,
+                })
           );
           bundle.entry?.push({
             resource: healthService,
@@ -319,12 +319,11 @@ export class NPIRegistrySyncSession {
             target: [buildReferenceFromResource(result!)],
           })
         ),
-        resourceSearch("Provenance")
-          .target({ type: result!.resourceType, id: result!.id! })
-          .agent({
-            type: provenanceResult.provenance.agent![0]!.who!.type!,
-            id: provenanceResult.provenance.agent![0]!.who!.reference!,
-          }).href
+        (search) =>
+          search.target({ type: result!.resourceType, id: result!.id! }).agent({
+            type: provenanceResult.provenance!.agent![0]!.who!.type!,
+            id: provenanceResult.provenance!.agent![0]!.who!.reference!,
+          })
       );
       bundle.entry?.push({
         resource: provenance,

--- a/packages/docs/packages/foundation/core.md
+++ b/packages/docs/packages/foundation/core.md
@@ -204,7 +204,7 @@ const [mergedResource, wasMerged] = createOr("merge", client, resource);
 const [mergedResource, wasMerged] = createOr("add", client, resource);
 
 // The search can be customized (instead of using the default identifiers)
-const [mergedResource, wasMerged] = createOr("merge", client, resource, resourceSearch("Patient").name("John Doe").href);
+const [mergedResource, wasMerged] = createOr("merge", client, resource, search => search.name("John Doe"));
 
 ```
 
@@ -217,10 +217,8 @@ The `searchAllPages` utility can be used to retrieve _all_ pages for a given sea
 ```typescript
 import { searchAllPages, resourceSearch, linkUrl } from "@bonfhir/core/r4b";
 
-const allPatients = await searchAllPages(
-  client,
-  "Patient",
-  resourceSearch("Patient").href
+const allActivePatients = await searchAllPages(client, "Patient", (search) =>
+  search.active("true")
 );
 
 // For paginating yourself
@@ -243,7 +241,7 @@ import { searchByPage } from "@bonfhir/core/r4b";
 await searchByPage(
   client,
   "Patient",
-  resourceSearch("Patient")._count(100)._total("accurate").href,
+  (search) => search._count(100)._total("accurate"),
   async ({ bundle, nav }) => {
     for (const patient of nav.resources) {
       // ...
@@ -300,6 +298,15 @@ If any search parameter is missing from the builder, you can always drop down to
 ```typescript
 resourceSearch("Organization").identifier("12345").builder.string("_count", 20)
   .href;
+```
+
+_The `resourceSearch` builder is integrated in the [`FhirRestfulClient` interface](http://localhost:4000/packages/foundation/core#fhir-client-interface)
+search method, so you can use it inlined:_
+
+```typescript
+const result = await client.search("Organization", (search) =>
+  search.name("IniTech")
+);
 ```
 
 ### Generic search builder

--- a/packages/medplum/r4b/medplum-fhir-restful-client-adapter.ts
+++ b/packages/medplum/r4b/medplum-fhir-restful-client-adapter.ts
@@ -4,10 +4,12 @@ import {
   ConditionalSearchParameters,
   ExtractResource,
   FhirRestfulClient,
+  FhirRestfulClientSearchParameters,
   GeneralParameters,
   HistoryParameters,
   isFhirResource,
   JSONPatchBody,
+  normalizeSearchParameters,
   ResourceType,
 } from "@bonfhir/core/r4b";
 import { MedplumClient, OperationOutcomeError } from "@medplum/core";
@@ -190,16 +192,28 @@ export function buildFhirRestfulClientAdapter(
 
     search<TResource extends ResourceType>(
       type?: TResource | null | undefined,
-      parameters?: string | null | undefined,
+      parameters?:
+        | FhirRestfulClientSearchParameters<TResource>
+        | null
+        | undefined,
       options?: GeneralParameters | null | undefined
     ): Promise<Bundle<ExtractResource<TResource>>> {
+      if (!type) {
+        throw new Error(
+          "type is a mandatory argument for search in the MedplumClient."
+        );
+      }
+
       if (options) {
         throw new Error(
           "search#options is not supported by the MedplumClient."
         );
       }
 
-      return client.search(type, parameters || undefined);
+      return client.search(
+        type,
+        normalizeSearchParameters<TResource>(type, parameters)
+      );
     },
 
     capabilities(): Promise<CapabilityStatement> {

--- a/packages/subscriptions/r4b/fhir-subscription.ts
+++ b/packages/subscriptions/r4b/fhir-subscription.ts
@@ -1,4 +1,4 @@
-import { build, FhirRestfulClient, resourceSearch } from "@bonfhir/core/r4b";
+import { build, FhirRestfulClient } from "@bonfhir/core/r4b";
 import { AuditEvent, FhirResource, Subscription } from "fhir/r4";
 import { createErrorAuditEvent } from "./audit-event";
 
@@ -99,11 +99,8 @@ export async function registerSubscriptions({
   for (const subscription of subscriptions) {
     try {
       const existingSubscription = (
-        await fhirClient.search(
-          "Subscription",
-          resourceSearch("Subscription").url(
-            new URL(subscription.endpoint, baseUrl || undefined).href
-          ).href
+        await fhirClient.search("Subscription", (search) =>
+          search.url(new URL(subscription.endpoint, baseUrl || undefined).href)
         )
       ).entry?.[0]?.resource;
 


### PR DESCRIPTION
## What is this about

This PR brings the `resourceSearch` builder directly in the `FhirRestfulClient` interface, to align all searches on using the builder by default.

## Issue ticket numbers

Fix #167

## How can this be tested?

N/A

## Known limitations/edge cases

This is a breaking change for the `FhirRestfulClient` implementations. They will have to use the `normalizeSearchParameters` helper function in their search implementation.