### PR TITLE
178-refactor-fhirsubscription-to-not-return-status-but-a-less-http-bound-result

### DIFF
--- a/packages/subscriptions-koa/r4b/middleware.ts
+++ b/packages/subscriptions-koa/r4b/middleware.ts
@@ -148,13 +148,11 @@ export async function fhirSubscriptions(config: FhirSubscriptionsConfig) {
           logger,
         });
 
-        context.status = result.status;
-        if (result.body) {
-          context.response.body = result.body;
-        }
-
-        if (result.headers) {
-          context.set(result.headers);
+        if (result == null) {
+          context.status = 204;
+        } else {
+          context.status = 200;
+          context.response.body = result;
         }
       } catch (error) {
         logger.error(error);

--- a/packages/subscriptions/r4b/fhir-subscription.ts
+++ b/packages/subscriptions/r4b/fhir-subscription.ts
@@ -14,7 +14,10 @@ export interface FhirSubscription<
   /** The Subscription endpoint to hit (webhook url). */
   endpoint: string;
 
-  /** The subscription handler. */
+  /**
+   * The subscription handler.
+   * If hosted in an HTTP setting, the returned value might be JSON-serialized back as the response.
+   */
   handler: FhirSubscriptionHandler<TResource>;
 }
 
@@ -22,7 +25,7 @@ export type FhirSubscriptionHandler<
   TResource extends FhirResource = FhirResource
 > = (
   args: FhirSubscriptionHandlerArgs<TResource>
-) => Promise<FhirSubscriptionHandlerResult>;
+) => FhirSubscriptionHandlerResult;
 
 export interface FhirSubscriptionHandlerArgs<
   TResource extends FhirResource = FhirResource
@@ -39,11 +42,11 @@ export interface FhirSubscriptionHandlerArgs<
     | undefined;
 }
 
-export interface FhirSubscriptionHandlerResult {
-  status: number;
-  body?: string | object | null | undefined;
-  headers?: Record<string, string> | null | undefined;
-}
+export type FhirSubscriptionHandlerResult =
+  | void
+  | Promise<void>
+  | object
+  | Promise<object>;
 
 export type SubscriptionLogger = Pick<
   typeof console,

--- a/samples/sample-api-koa/src/communication-requests.ts
+++ b/samples/sample-api-koa/src/communication-requests.ts
@@ -5,10 +5,7 @@ export const communicationRequests: FhirSubscription<CommunicationRequest> = {
   criteria: "CommunicationRequest",
   reason: "Send communication requests",
   endpoint: "/fhir/communication-requests",
-  async handler({ resource }) {
-    console.log(resource);
-    return {
-      status: 204,
-    };
+  async handler({ resource, logger }) {
+    logger?.info(resource);
   },
 };


### PR DESCRIPTION
## What is this about

This PR refactor the subscription handler to simply return an object, separating it from a pure HTTP response.

## Issue ticket numbers

Fix #178

## How can this be tested?

Run the sample API and create a `CommunicationRequest`.

## Known limitations/edge cases

N/A