### PR TITLE
177-create-a-composesubscriptionhandler-that-allows-to-compose-multiple-fhirsubscription-handler-into-the-same-fhirsubscription-easily

### DIFF
--- a/packages/docs/packages/integrations/subscriptions.md
+++ b/packages/docs/packages/integrations/subscriptions.md
@@ -132,6 +132,25 @@ This will create the subscriptions on startup, and invoke the handler when recei
 See the [Sample API code](https://github.com/bonfhir/bonfhir/blob/main/samples/sample-api-koa) for a live
 example.
 
+## Utilities
+
+### `composeHandlers`
+
+The `composeHandlers` utility allows to execute multiple subscription handlers in the same subscription.
+The execution can be carried out sequentially or in parallel.
+
+```typescript
+import { composeHandlers, FhirSubscription } from "@bonfhir/subscriptions/r4b";
+import { CommunicationRequest } from "fhir/r4";
+
+export const communicationRequests: FhirSubscription<CommunicationRequest> = {
+  criteria: "CommunicationRequest",
+  reason: "Process communication requests",
+  endpoint: "/fhir/communication-requests",
+  handlers: composeHandlers([...], "parallel")
+};
+```
+
 ## Configuration
 
 ### Webhook security

--- a/packages/subscriptions/jest.config.cjs
+++ b/packages/subscriptions/jest.config.cjs
@@ -1,0 +1,8 @@
+/** @type {import('jest').Config} */
+const config = {
+  transform: {
+    "^.+\\.tsx?$": "esbuild-jest",
+  },
+};
+
+module.exports = config;

--- a/packages/subscriptions/package.json
+++ b/packages/subscriptions/package.json
@@ -11,7 +11,8 @@
     "clean": "rimraf dist/",
     "format": "prettier --loglevel warn --write ./**/*.ts && eslint --fix ./**/*.ts",
     "package:create": "yarn build && node package.js pack",
-    "package:publish": "yarn build && node package.js publish"
+    "package:publish": "yarn build && node package.js publish",
+    "test": "jest"
   },
   "packageManager": "yarn@3.3.1",
   "devDependencies": {
@@ -21,6 +22,8 @@
     "@bonfhir/typescript-config": "^1.0.1-alpha.1",
     "@types/fhir": "^0.0.35",
     "@types/node": "^18.15.3",
+    "esbuild": "^0.17.12",
+    "esbuild-jest": "^0.5.0",
     "eslint": "^8.36.0",
     "jest": "^29.5.0",
     "prettier": "^2.8.4",

--- a/packages/subscriptions/r4b/handlers.test.ts
+++ b/packages/subscriptions/r4b/handlers.test.ts
@@ -1,0 +1,132 @@
+import {
+  FhirSubscriptionHandler,
+  FhirSubscriptionHandlerArgs,
+} from "./fhir-subscription";
+import { composeHandlers } from "./handlers";
+
+describe("handlers", () => {
+  describe("composeHandlers", () => {
+    describe("sequential", () => {
+      it("execute handlers in order", async () => {
+        const handlers: FhirSubscriptionHandler[] = [
+          async () => {
+            return 1;
+          },
+          async () => {
+            return 2;
+          },
+        ];
+
+        const result = await composeHandlers(
+          handlers,
+          "sequential"
+        )({} as FhirSubscriptionHandlerArgs);
+
+        expect(result).toMatchObject([1, 2]);
+      });
+
+      it("handles errors", async () => {
+        let secondHandlerExecuted = false;
+        const handlers: FhirSubscriptionHandler[] = [
+          async () => {
+            throw "ERROR!";
+          },
+          async () => {
+            secondHandlerExecuted = true;
+          },
+        ];
+
+        await expect(
+          async () =>
+            await composeHandlers(
+              handlers,
+              "sequential"
+            )({} as FhirSubscriptionHandlerArgs)
+        ).rejects.toThrowError();
+        expect(secondHandlerExecuted).toBeFalsy();
+      });
+    });
+
+    describe("sequential-all", () => {
+      it("execute handlers in order", async () => {
+        const handlers: FhirSubscriptionHandler[] = [
+          async () => {
+            return 1;
+          },
+          async () => {
+            return 2;
+          },
+        ];
+
+        const result = await composeHandlers(
+          handlers,
+          "sequential-all"
+        )({} as FhirSubscriptionHandlerArgs);
+
+        expect(result).toMatchObject([1, 2]);
+      });
+
+      it("handles errors", async () => {
+        let secondHandlerExecuted = false;
+        const handlers: FhirSubscriptionHandler[] = [
+          async () => {
+            throw "ERROR!";
+          },
+          async () => {
+            secondHandlerExecuted = true;
+          },
+        ];
+
+        await expect(
+          async () =>
+            await composeHandlers(
+              handlers,
+              "sequential-all"
+            )({} as FhirSubscriptionHandlerArgs)
+        ).rejects.toThrowError();
+        expect(secondHandlerExecuted).toBeTruthy();
+      });
+    });
+
+    describe("parallel", () => {
+      it("execute handlers", async () => {
+        const handlers: FhirSubscriptionHandler[] = [
+          async () => {
+            return 1;
+          },
+          async () => {
+            return 2;
+          },
+        ];
+
+        const result = await composeHandlers(
+          handlers,
+          "parallel"
+        )({} as FhirSubscriptionHandlerArgs);
+
+        expect(result).toMatchObject(expect.arrayContaining([1, 2]));
+      });
+
+      it("handles errors", async () => {
+        let secondHandlerExecuted = false;
+        const handlers: FhirSubscriptionHandler[] = [
+          async () => {
+            throw "ERROR!";
+          },
+          async () => {
+            secondHandlerExecuted = true;
+          },
+        ];
+
+        await expect(
+          async () =>
+            await composeHandlers(
+              handlers,
+              "parallel"
+            )({} as FhirSubscriptionHandlerArgs)
+        ).rejects.toThrowError();
+        expect(secondHandlerExecuted).toBeTruthy();
+      });
+    });
+  });
+});

--- a/packages/subscriptions/r4b/handlers.ts
+++ b/packages/subscriptions/r4b/handlers.ts
@@ -1,0 +1,99 @@
+import { FhirResource } from "fhir/r4";
+import { FhirSubscriptionHandler } from "./fhir-subscription";
+
+export type ComposeExecutionMode = "sequential" | "sequential-all" | "parallel";
+
+/**
+ * Create a high-level handler that can execute multiple handlers as part of the same FhirSubscription.
+ * @param handlers The handlers to execute.
+ * @param executionMode How to execute the handlers:
+ *  - sequential: execute handlers in order, stop at the first error
+ *  - sequential-all: execute handlers in order, all of them, and throw the errors at the end
+ *  - parallel: execute handlers in parallel, all of them, and throw the errors at the end
+ * @returns An array of handlers results if all of them are successful.
+ */
+export const composeHandlers = <TResource extends FhirResource = FhirResource>(
+  handlers: Array<FhirSubscriptionHandler<TResource>>,
+  executionMode?: ComposeExecutionMode | null | undefined
+): FhirSubscriptionHandler<TResource> => {
+  executionMode ||= "sequential";
+
+  switch (executionMode) {
+    case "sequential":
+      return async (args) => {
+        const result = [];
+        try {
+          for (const handler of handlers) {
+            result.push(await handler(args));
+          }
+        } catch (error) {
+          args.logger?.error(error);
+          throw error instanceof Error
+            ? error
+            : new Error(`${error}`, { cause: error });
+        }
+
+        return result;
+      };
+
+    case "sequential-all":
+      return async (args) => {
+        const result = [];
+        for (const handler of handlers) {
+          try {
+            result.push(await handler(args));
+          } catch (error) {
+            args.logger?.error(error);
+            result.push(
+              error instanceof Error
+                ? error
+                : new Error(`${error}`, { cause: error })
+            );
+          }
+        }
+
+        const processingErrors = result.filter(
+          (x) => x instanceof Error
+        ) as Error[];
+        if (processingErrors.length) {
+          args.logger?.warn(result);
+          throw new Error(processingErrors.map((x) => x.message).join("|"), {
+            cause: result,
+          });
+        }
+
+        return result;
+      };
+
+    case "parallel":
+      return async (args) => {
+        const result = await Promise.all(
+          handlers.map(async (handler) => {
+            try {
+              return await handler(args);
+            } catch (error) {
+              args.logger?.error(error);
+              return error instanceof Error
+                ? error
+                : new Error(`${error}`, { cause: error });
+            }
+          })
+        );
+
+        const processingErrors = result.filter(
+          (x) => x instanceof Error
+        ) as Error[];
+        if (processingErrors.length) {
+          args.logger?.warn(result);
+          throw new Error(processingErrors.map((x) => x.message).join("|"), {
+            cause: result,
+          });
+        }
+
+        return result;
+      };
+
+    default:
+      throw new Error(`Unknown executionMode ${executionMode}`);
+  }
+};

--- a/packages/subscriptions/r4b/index.ts
+++ b/packages/subscriptions/r4b/index.ts
@@ -1,2 +1,3 @@
 export * from "./audit-event";
 export * from "./fhir-subscription";
+export * from "./handlers";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2337,6 +2337,8 @@ __metadata:
     "@bonfhir/typescript-config": ^1.0.1-alpha.1
     "@types/fhir": ^0.0.35
     "@types/node": ^18.15.3
+    esbuild: ^0.17.12
+    esbuild-jest: ^0.5.0
     eslint: ^8.36.0
     jest: ^29.5.0
     prettier: ^2.8.4


### PR DESCRIPTION
## What is this about

This PR adds the `composeHandlers` utility method to allow executing multiple handlers sequentially or in parallel for a single `FhirSubscription`.

## Issue ticket numbers

Fix #177

## How can this be tested?

N/A

## Known limitations/edge cases

N/A