### PR TITLE
feat(core): :sparkles: add default `systemLabels` and the ability to set it at the adapter level

### DIFF
--- a/packages/core/r4b/data-type-adapter.test.ts
+++ b/packages/core/r4b/data-type-adapter.test.ts
@@ -73,6 +73,20 @@ describe("intlFhirDataTypeAdapter", () => {
     });
   });
 
+  describe("options", () => {
+    it("applies global system labels", () => {
+      const adapter = intlFhirDataTypeAdapter("en-us", {
+        systemsLabels: { "http://hl7.org/fhir/sid/us-ssn": "SSN (US)" },
+      });
+      expect(
+        adapter.identifier.format({
+          system: "http://hl7.org/fhir/sid/us-ssn",
+          value: "123456789",
+        })
+      ).toEqual("SSN (US): 123456789");
+    });
+  });
+
   describe("message", () => {
     const adapter = intlFhirDataTypeAdapter("en-us");
 

--- a/packages/core/r4b/data-type-adapter.ts
+++ b/packages/core/r4b/data-type-adapter.ts
@@ -47,6 +47,7 @@ import {
   fhirHumanNameTypeAdapter,
 } from "./data-types/humanName";
 import {
+  FhirIdentifierFormatOptions,
   FhirIdentifierTypeAdapter,
   fhirIdentifierTypeAdapter,
 } from "./data-types/identifier";
@@ -203,13 +204,23 @@ export type FhirDataTypeAdapterMessageExpression =
   | null
   | undefined;
 
+export interface IntlFhirDataTypeAdapterOptions {
+  /**
+   * The default labels to use for `identifier.system`.
+   *
+   * @see DEFAULT_SYSTEMS_LABELS for default values if this is not set.
+   */
+  systemsLabels?: FhirIdentifierFormatOptions["systemsLabels"];
+}
+
 /**
  * Return a {@link FhirDataTypeAdapter} that uses the [`Intl` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl)
  * (ECMAScript Internationalization API)
  * @param locale - see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument
  */
 export function intlFhirDataTypeAdapter(
-  locale?: string | undefined
+  locale?: string | undefined,
+  options?: IntlFhirDataTypeAdapterOptions | null | undefined
 ): FhirDataTypeAdapter {
   // JIT locale check
   Intl.DateTimeFormat(locale);
@@ -225,7 +236,7 @@ export function intlFhirDataTypeAdapter(
     dateTime: fhirDateTimeTypeAdapter(locale),
     decimal: fhirDecimalTypeAdapter(locale),
     id: fhirIdTypeAdapter(locale),
-    identifier: fhirIdentifierTypeAdapter(locale),
+    identifier: fhirIdentifierTypeAdapter(locale, options?.systemsLabels),
     instant: fhirInstantTypeAdapter(locale),
     integer: fhirIntegerTypeAdapter(locale),
     markdown: fhirMarkdownTypeAdapter(locale),

--- a/packages/core/r4b/data-types/identifier.test.ts
+++ b/packages/core/r4b/data-types/identifier.test.ts
@@ -66,6 +66,11 @@ describe("fhirIdentifierTypeAdapter", () => {
         short: "NAS: 123:456:789",
         value: "123:456:789",
       }).map(([style, expected]) => [identifier, { style }, expected]),
+      [
+        { system: "http://hl7.org/fhir/sid/us-ssn", value: "123456789" },
+        undefined,
+        "SSN: 123456789",
+      ],
     ])("parse %p with %p", (value, options, expected) => {
       expect(adapter.format(value, options)).toEqual(expected);
     });


### PR DESCRIPTION
## What is this about

This PR adds default values for `systemLabels` in the `identifier` adapter for [Known Identifiers](https://hl7.org/fhir/identifier-registry.html).
It also allows to set a mapping globally at the adapter level. 

## Issue ticket numbers

Fix #185

## How can this be tested?

Unit tests amended with new features.

## Known limitations/edge cases

I did not map all the Drivers' licenses OIDs. I don't know if we should...
