### PR TITLE
Update `typescript` to 5.x across all packages

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -116,6 +116,7 @@
             "url": "./fhir/r4b/definitions/fhir.schema.json"
           }
         ],
+        "nxConsole.enableTelemetry": false,
         "terminal.integrated.defaultProfile.linux": "zsh"
       }
     }

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,21 +1,20 @@
+enableTelemetry: 0
+
 nodeLinker: node-modules
 
 packageExtensions:
   "@docsearch/react@*":
     dependencies:
       "@algolia/client-search": ">= 4.9.1 < 6"
-
-  "@parcel/optimizer-image@*":
-    dependencies:
-      "@parcel/core": "*"
-  
-  "@parcel/types@*":
-    dependencies:
-      "@parcel/core": "*"
-
   "@nrwl/devkit@*":
     dependencies:
       typescript: ^3 || ^4
+  "@parcel/optimizer-image@*":
+    dependencies:
+      "@parcel/core": "*"
+  "@parcel/types@*":
+    dependencies:
+      "@parcel/core": "*"
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-typescript.cjs

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -29,13 +29,13 @@
     "fetch-vcr": "^3.2.0",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
-    "jest-mock-extended": "^3.0.3",
+    "jest-mock-extended": "^3.0.4",
     "prettier": "^2.8.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^4.4.0",
-    "tsup": "^6.6.3",
-    "typescript": "^4.9.5"
+    "tsup": "^6.7.0",
+    "typescript": "^5.0.3"
   },
   "dependencies": {
     "@bonfhir/ui-components": "^0.1.0-alpha.7"

--- a/packages/charlson-comorbidity-index/package.json
+++ b/packages/charlson-comorbidity-index/package.json
@@ -31,8 +31,8 @@
     "jest": "^29.5.0",
     "prettier": "^2.8.4",
     "rimraf": "^4.4.0",
-    "tsup": "^6.6.3",
-    "typescript": "^4.9.5"
+    "tsup": "^6.7.0",
+    "typescript": "^5.0.3"
   },
   "dependencies": {
     "@bonfhir/core": "^1.0.0-alpha.13"

--- a/packages/charlson-comorbidity-index/r4b/calculator.test.ts
+++ b/packages/charlson-comorbidity-index/r4b/calculator.test.ts
@@ -2,12 +2,12 @@
 import { buildCodeableConcept } from "@bonfhir/core/r4b";
 import { fake } from "@bonfhir/test-support/r4b";
 import { ConceptMap, Patient } from "fhir/r4";
+import icd10CodesConceptmap from "./__fixtures__/icd10-codes-conceptmap.fhir.json";
 import {
   CharlsonComorbidityIndexResultError,
   CharlsonComorbidityIndexResultSuccess,
   computeCharlsonComorbidityIndex,
 } from "./calculator";
-import icd10CodesConceptmap from "./__fixtures__/icd10-codes-conceptmap.fhir.json";
 
 describe("charlson-comorbidity-calculator", () => {
   it("validate missing patient", () => {

--- a/packages/cmsdotgov/package.json
+++ b/packages/cmsdotgov/package.json
@@ -30,8 +30,8 @@
     "jest": "^29.5.0",
     "prettier": "^2.8.4",
     "rimraf": "^4.4.0",
-    "tsup": "^6.6.3",
-    "typescript": "^4.9.5"
+    "tsup": "^6.7.0",
+    "typescript": "^5.0.3"
   },
   "dependencies": {
     "@bonfhir/core": "^1.0.0-alpha.13",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -38,8 +38,8 @@
     "prettier": "^2.8.4",
     "rimraf": "^4.4.0",
     "ts-node": "^10.9.1",
-    "tsup": "^6.6.3",
-    "typescript": "^4.9.5"
+    "tsup": "^6.7.0",
+    "typescript": "^5.0.3"
   },
   "dependencies": {
     "chalk": "^5.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,13 +27,13 @@
     "esbuild-jest": "^0.5.0",
     "eslint": "^8.36.0",
     "jest": "^29.5.0",
-    "jest-mock-extended": "^3.0.3",
+    "jest-mock-extended": "^3.0.4",
     "localized-address-format": "^1.3.0",
     "marked": "^4.2.12",
     "prettier": "^2.8.4",
     "rimraf": "^4.4.0",
-    "tsup": "^6.6.3",
-    "typescript": "^4.9.5"
+    "tsup": "^6.7.0",
+    "typescript": "^5.0.3"
   },
   "dependencies": {
     "@types/fhir": "^0.0.35"

--- a/packages/core/r4b/builders.ts
+++ b/packages/core/r4b/builders.ts
@@ -2,9 +2,9 @@ import { CodeableConcept, Reference } from "fhir/r4";
 import { narrative } from "./narratives";
 import {
   ExtractResource,
-  isDomainResource,
   ResourceType,
   WithRequired,
+  isDomainResource,
 } from "./types";
 
 /**

--- a/packages/core/r4b/bundle-navigator.test.ts
+++ b/packages/core/r4b/bundle-navigator.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { Bundle, Organization, Patient, Provenance } from "fhir/r4";
+import * as patientsListFixture from "./__fixtures__/bundle-navigator.list-patients.test.fhir.json";
 import { buildReferenceFromResource } from "./builders";
 import { bundleNavigator } from "./bundle-navigator";
-import * as patientsListFixture from "./__fixtures__/bundle-navigator.list-patients.test.fhir.json";
 
 describe("BundleNavigator", () => {
   const emptyBundle: Bundle = {

--- a/packages/core/r4b/fhir-restful-client.ts
+++ b/packages/core/r4b/fhir-restful-client.ts
@@ -1,6 +1,6 @@
 import { Bundle, CapabilityStatement, FhirResource, Identifier } from "fhir/r4";
 import { BundleNavigator, bundleNavigator } from "./bundle-navigator";
-import { merge, MergeResult } from "./merge";
+import { MergeResult, merge } from "./merge";
 import { ExtractPatchBuilder, resourcePatch } from "./resource-patch";
 import { ExtractSearchBuilder, resourceSearch } from "./resource-search";
 import { fhirSearch } from "./search-builder";

--- a/packages/core/r4b/period-calculator.test.ts
+++ b/packages/core/r4b/period-calculator.test.ts
@@ -3,8 +3,8 @@ import { addDays } from "date-fns";
 import { MedicationDispense, Period } from "fhir/r4";
 import { build } from "./builders";
 import {
-  buildTimelineOfResourcesWithPeriods,
   Timeline,
+  buildTimelineOfResourcesWithPeriods,
 } from "./period-calculator";
 import { WithRequired } from "./types";
 

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -39,7 +39,7 @@
     "@types/copyfiles": "^2.4.1",
     "copyfiles": "^2.4.1",
     "rimraf": "^4.4.0",
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.3"
   },
   "browserslist": {
     "production": [

--- a/packages/fhir-query/package.json
+++ b/packages/fhir-query/package.json
@@ -33,13 +33,13 @@
     "fetch-vcr": "^3.2.0",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
-    "jest-mock-extended": "^3.0.3",
+    "jest-mock-extended": "^3.0.4",
     "prettier": "^2.8.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^4.4.0",
-    "tsup": "^6.6.3",
-    "typescript": "^4.9.5"
+    "tsup": "^6.7.0",
+    "typescript": "^5.0.3"
   },
   "dependencies": {
     "@bonfhir/core": "^1.0.0-alpha.13"

--- a/packages/medplum/package.json
+++ b/packages/medplum/package.json
@@ -28,8 +28,8 @@
     "jest": "^29.5.0",
     "prettier": "^2.8.4",
     "rimraf": "^4.4.0",
-    "tsup": "^6.6.3",
-    "typescript": "^4.9.5"
+    "tsup": "^6.7.0",
+    "typescript": "^5.0.3"
   },
   "dependencies": {
     "@bonfhir/core": "^1.0.0-alpha.13"

--- a/packages/nih-nlm/package.json
+++ b/packages/nih-nlm/package.json
@@ -30,8 +30,8 @@
     "jest": "^29.5.0",
     "prettier": "^2.8.4",
     "rimraf": "^4.4.0",
-    "tsup": "^6.6.3",
-    "typescript": "^4.9.5"
+    "tsup": "^6.7.0",
+    "typescript": "^5.0.3"
   },
   "dependencies": {
     "@bonfhir/core": "^1.0.0-alpha.13",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "prettier": "^2.8.4",
     "prettier-plugin-organize-imports": "^3.2.2",
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.3"
   },
   "devDependencies": {
     "@types/prettier": "^2.7.2"

--- a/packages/subscriptions-koa/package.json
+++ b/packages/subscriptions-koa/package.json
@@ -29,8 +29,8 @@
     "koa": "^2.14.1",
     "prettier": "^2.8.4",
     "rimraf": "^4.4.0",
-    "tsup": "^6.6.3",
-    "typescript": "^4.9.5"
+    "tsup": "^6.7.0",
+    "typescript": "^5.0.3"
   },
   "dependencies": {
     "@bonfhir/core": "^1.0.0-alpha.13",

--- a/packages/subscriptions/package.json
+++ b/packages/subscriptions/package.json
@@ -28,8 +28,8 @@
     "jest": "^29.5.0",
     "prettier": "^2.8.4",
     "rimraf": "^4.4.0",
-    "tsup": "^6.6.3",
-    "typescript": "^4.9.5"
+    "tsup": "^6.7.0",
+    "typescript": "^5.0.3"
   },
   "dependencies": {
     "@bonfhir/core": "^1.0.0-alpha.13"

--- a/packages/terminology/package.json
+++ b/packages/terminology/package.json
@@ -26,8 +26,8 @@
     "jest": "^29.5.0",
     "prettier": "^2.8.4",
     "rimraf": "^4.4.0",
-    "tsup": "^6.6.3",
-    "typescript": "^4.9.5"
+    "tsup": "^6.7.0",
+    "typescript": "^5.0.3"
   },
   "prettier": "@bonfhir/prettier-config"
 }

--- a/packages/test-support/jest.config.cjs
+++ b/packages/test-support/jest.config.cjs
@@ -1,7 +1,16 @@
+/** @type {import('esbuild-jest').Options} */
+const esbuildOptions = {
+  // Setting `sourcemap` to `true` is needed[0] to correctly report line numbers
+  // in Jest's built-in coverage reporting.
+  //
+  // [0]: https://github.com/aelbore/esbuild-jest/issues/79
+  sourcemap: true,
+};
+
 /** @type {import('jest').Config} */
 const config = {
   transform: {
-    "^.+\\.tsx?$": "esbuild-jest",
+    "^.+\\.tsx?$": ["esbuild-jest", esbuildOptions],
   },
 };
 

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -29,8 +29,8 @@
     "jest": "^29.5.0",
     "prettier": "^2.8.4",
     "rimraf": "^4.4.0",
-    "tsup": "^6.6.3",
-    "typescript": "^4.9.5"
+    "tsup": "^6.7.0",
+    "typescript": "^5.0.3"
   },
   "dependencies": {
     "@bonfhir/core": "^1.0.0-alpha.13",

--- a/packages/test-support/r4b/fakes.test.ts
+++ b/packages/test-support/r4b/fakes.test.ts
@@ -3,6 +3,16 @@ import { DomainResource } from "fhir/r4";
 import { fake } from "./fakes";
 
 describe("fakes", () => {
+  it("throws an `Error` when attempting to generate an unrecognized resource type", () => {
+    const unrecognizedResourceTypeName = `BonfhirSpringTestExampleStructThingy`;
+
+    const generatingAnUnknownResourceType = () =>
+      // @ts-expect-error as this explicitly tests using an invalid type
+      fake(unrecognizedResourceTypeName);
+
+    expect(generatingAnUnknownResourceType).toThrowError(Error);
+  });
+
   it.each(DomainResourceTypes)("generate fakes for %s", (resourceType) => {
     const resource = fake(resourceType as ResourceType);
     expect((resource as DomainResource).text?.div).not.toBeFalsy();

--- a/packages/test-support/r4b/synthetic.test.ts
+++ b/packages/test-support/r4b/synthetic.test.ts
@@ -27,4 +27,17 @@ describe("synthetic", () => {
     });
     expect(result2.valueQuantity?.value).toBeGreaterThan(10);
   });
+
+  it("throws an error when no synthetic resources are found matching the requested resourceType", async () => {
+    // We request synthetic of a resource type we know probably doesn't exist
+    // (we made it up) to more-or-less guarantee the function finds no matches,
+    // triggering the error.
+    const requestingAbsentResourceType = () =>
+      // @ts-expect-error as we're deliberately requesting an non-existant resource
+      synthetic("SomeExampleCustomResourceType");
+
+    expect(requestingAbsentResourceType).rejects.toThrowError(
+      /unable to find/i
+    );
+  });
 });

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -7,6 +7,6 @@
   "packageManager": "yarn@3.3.1",
   "dependencies": {
     "@types/node": "^18.15.3",
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.3"
   }
 }

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -35,13 +35,13 @@
     "fetch-vcr": "^3.2.0",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
-    "jest-mock-extended": "^3.0.3",
+    "jest-mock-extended": "^3.0.4",
     "prettier": "^2.8.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^4.4.0",
-    "tsup": "^6.6.3",
-    "typescript": "^4.9.5"
+    "tsup": "^6.7.0",
+    "typescript": "^5.0.3"
   },
   "dependencies": {
     "@bonfhir/core": "^1.0.0-alpha.13",

--- a/packages/ui-components/r4b/index.tsx
+++ b/packages/ui-components/r4b/index.tsx
@@ -1,4 +1,4 @@
-export * from "./display";
 export * from "./FhirUIComponentsContext";
 export * from "./FhirUIComponentsProvider";
 export * from "./FhirUIComponentsRenderer";
+export * from "./display";

--- a/samples/ehr-sample-app/package.json
+++ b/samples/ehr-sample-app/package.json
@@ -34,11 +34,11 @@
     "eslint": "^8.36.0",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
-    "jest-mock-extended": "^3.0.3",
+    "jest-mock-extended": "^3.0.4",
     "parcel": "^2.8.3",
     "prettier": "^2.8.4",
     "rimraf": "^4.4.0",
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.3"
   },
   "dependencies": {
     "@bonfhir/antd": "^0.1.0-alpha.0",

--- a/samples/sample-api-koa/package.json
+++ b/samples/sample-api-koa/package.json
@@ -30,7 +30,7 @@
     "prettier": "^2.8.4",
     "rimraf": "^4.4.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.3"
   },
   "dependencies": {
     "@bonfhir/core": "^1.0.0-alpha.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1954,13 +1954,13 @@ __metadata:
     fetch-vcr: ^3.2.0
     jest: ^29.5.0
     jest-environment-jsdom: ^29.5.0
-    jest-mock-extended: ^3.0.3
+    jest-mock-extended: ^3.0.4
     prettier: ^2.8.4
     react: ^18.2.0
     react-dom: ^18.2.0
     rimraf: ^4.4.0
-    tsup: ^6.6.3
-    typescript: ^4.9.5
+    tsup: ^6.7.0
+    typescript: ^5.0.3
   peerDependencies:
     antd: ^5.0.0
     react: "*"
@@ -1988,8 +1988,8 @@ __metadata:
     jest: ^29.5.0
     prettier: ^2.8.4
     rimraf: ^4.4.0
-    tsup: ^6.6.3
-    typescript: ^4.9.5
+    tsup: ^6.7.0
+    typescript: ^5.0.3
   languageName: unknown
   linkType: soft
 
@@ -2014,8 +2014,8 @@ __metadata:
     jest: ^29.5.0
     prettier: ^2.8.4
     rimraf: ^4.4.0
-    tsup: ^6.6.3
-    typescript: ^4.9.5
+    tsup: ^6.7.0
+    typescript: ^5.0.3
   languageName: unknown
   linkType: soft
 
@@ -2048,8 +2048,8 @@ __metadata:
     rimraf: ^4.4.0
     to-words: ^3.5.0
     ts-node: ^10.9.1
-    tsup: ^6.6.3
-    typescript: ^4.9.5
+    tsup: ^6.7.0
+    typescript: ^5.0.3
     yargs: ^17.7.1
   bin:
     bonfhir-codegen: index.js
@@ -2071,13 +2071,13 @@ __metadata:
     esbuild-jest: ^0.5.0
     eslint: ^8.36.0
     jest: ^29.5.0
-    jest-mock-extended: ^3.0.3
+    jest-mock-extended: ^3.0.4
     localized-address-format: ^1.3.0
     marked: ^4.2.12
     prettier: ^2.8.4
     rimraf: ^4.4.0
-    tsup: ^6.6.3
-    typescript: ^4.9.5
+    tsup: ^6.7.0
+    typescript: ^5.0.3
   languageName: unknown
   linkType: soft
 
@@ -2100,7 +2100,7 @@ __metadata:
     react: ^17.0.2
     react-dom: ^17.0.2
     rimraf: ^4.4.0
-    typescript: ^4.9.5
+    typescript: ^5.0.3
   languageName: unknown
   linkType: soft
 
@@ -2131,7 +2131,7 @@ __metadata:
     eslint: ^8.36.0
     jest: ^29.5.0
     jest-environment-jsdom: ^29.5.0
-    jest-mock-extended: ^3.0.3
+    jest-mock-extended: ^3.0.4
     parcel: ^2.8.3
     prettier: ^2.8.4
     react: ^18.2.0
@@ -2140,7 +2140,7 @@ __metadata:
     react-router-dom: ^6.8.0
     rimraf: ^4.4.0
     styled-components: ^5.3.6
-    typescript: ^4.9.5
+    typescript: ^5.0.3
   languageName: unknown
   linkType: soft
 
@@ -2181,13 +2181,13 @@ __metadata:
     fetch-vcr: ^3.2.0
     jest: ^29.5.0
     jest-environment-jsdom: ^29.5.0
-    jest-mock-extended: ^3.0.3
+    jest-mock-extended: ^3.0.4
     prettier: ^2.8.4
     react: ^18.2.0
     react-dom: ^18.2.0
     rimraf: ^4.4.0
-    tsup: ^6.6.3
-    typescript: ^4.9.5
+    tsup: ^6.7.0
+    typescript: ^5.0.3
   peerDependencies:
     "@tanstack/react-query": ^4.0.0
     react: "*"
@@ -2212,8 +2212,8 @@ __metadata:
     jest: ^29.5.0
     prettier: ^2.8.4
     rimraf: ^4.4.0
-    tsup: ^6.6.3
-    typescript: ^4.9.5
+    tsup: ^6.7.0
+    typescript: ^5.0.3
   peerDependencies:
     "@medplum/core": ^2.0.0
   languageName: unknown
@@ -2239,8 +2239,8 @@ __metadata:
     jest: ^29.5.0
     prettier: ^2.8.4
     rimraf: ^4.4.0
-    tsup: ^6.6.3
-    typescript: ^4.9.5
+    tsup: ^6.7.0
+    typescript: ^5.0.3
   languageName: unknown
   linkType: soft
 
@@ -2251,7 +2251,7 @@ __metadata:
     "@types/prettier": ^2.7.2
     prettier: ^2.8.4
     prettier-plugin-organize-imports: ^3.2.2
-    typescript: ^4.9.5
+    typescript: ^5.0.3
   languageName: unknown
   linkType: soft
 
@@ -2294,7 +2294,7 @@ __metadata:
     prettier: ^2.8.4
     rimraf: ^4.4.0
     ts-node: ^10.9.1
-    typescript: ^4.9.5
+    typescript: ^5.0.3
   languageName: unknown
   linkType: soft
 
@@ -2318,8 +2318,8 @@ __metadata:
     koa: ^2.14.1
     prettier: ^2.8.4
     rimraf: ^4.4.0
-    tsup: ^6.6.3
-    typescript: ^4.9.5
+    tsup: ^6.7.0
+    typescript: ^5.0.3
   peerDependencies:
     "@koa/router": ">=12.0.0"
     koa: ^2.0.0
@@ -2343,8 +2343,8 @@ __metadata:
     jest: ^29.5.0
     prettier: ^2.8.4
     rimraf: ^4.4.0
-    tsup: ^6.6.3
-    typescript: ^4.9.5
+    tsup: ^6.7.0
+    typescript: ^5.0.3
   languageName: unknown
   linkType: soft
 
@@ -2362,8 +2362,8 @@ __metadata:
     jest: ^29.5.0
     prettier: ^2.8.4
     rimraf: ^4.4.0
-    tsup: ^6.6.3
-    typescript: ^4.9.5
+    tsup: ^6.7.0
+    typescript: ^5.0.3
   languageName: unknown
   linkType: soft
 
@@ -2387,8 +2387,8 @@ __metadata:
     jest: ^29.5.0
     prettier: ^2.8.4
     rimraf: ^4.4.0
-    tsup: ^6.6.3
-    typescript: ^4.9.5
+    tsup: ^6.7.0
+    typescript: ^5.0.3
   languageName: unknown
   linkType: soft
 
@@ -2397,7 +2397,7 @@ __metadata:
   resolution: "@bonfhir/typescript-config@workspace:packages/typescript-config"
   dependencies:
     "@types/node": ^18.15.3
-    typescript: ^4.9.5
+    typescript: ^5.0.3
   languageName: unknown
   linkType: soft
 
@@ -2425,13 +2425,13 @@ __metadata:
     fetch-vcr: ^3.2.0
     jest: ^29.5.0
     jest-environment-jsdom: ^29.5.0
-    jest-mock-extended: ^3.0.3
+    jest-mock-extended: ^3.0.4
     prettier: ^2.8.4
     react: ^18.2.0
     react-dom: ^18.2.0
     rimraf: ^4.4.0
-    tsup: ^6.6.3
-    typescript: ^4.9.5
+    tsup: ^6.7.0
+    typescript: ^5.0.3
   peerDependencies:
     "@tanstack/react-query": ^4.0.0
     react: "*"
@@ -15894,15 +15894,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-mock-extended@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "jest-mock-extended@npm:3.0.3"
+"jest-mock-extended@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "jest-mock-extended@npm:3.0.4"
   dependencies:
     ts-essentials: ^7.0.3
   peerDependencies:
     jest: ^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0
-    typescript: ^3.0.0 || ^4.0.0
-  checksum: 826d619b0e9e5f4a7691259a5f8919fd40d6468d13d9c0d8c0724d8ebd106404e7416079692f4dce5b4d42e3579b5948ea789b951ab6858ab76c192113e1d759
+    typescript: ^3.0.0 || ^4.0.0 || ^5.0.0
+  checksum: f861253c63508b30d971fbbbc1bf2911ff4406cd260d0e23483a1d4514898b18ba5efbd43fbdf6d94996dc09b20eb1aad1b46aeaea9c99244ba12dc99814fd3f
   languageName: node
   linkType: hard
 
@@ -24725,9 +24725,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsup@npm:^6.6.3":
-  version: 6.6.3
-  resolution: "tsup@npm:6.6.3"
+"tsup@npm:^6.7.0":
+  version: 6.7.0
+  resolution: "tsup@npm:6.7.0"
   dependencies:
     bundle-require: ^4.0.0
     cac: ^6.7.12
@@ -24746,7 +24746,7 @@ __metadata:
   peerDependencies:
     "@swc/core": ^1
     postcss: ^8.4.12
-    typescript: ^4.1.0
+    typescript: ">=4.1.0"
   peerDependenciesMeta:
     "@swc/core":
       optional: true
@@ -24757,7 +24757,7 @@ __metadata:
   bin:
     tsup: dist/cli-default.js
     tsup-node: dist/cli-node.js
-  checksum: 4fa45fd7493971e5bf1f142a2590eabc1de536dc251d4b90bfce7dfaf1d7f40e19ef04ee541f9d2ab6a55841b72d265b7ddd3ea70c6371d746b5aed782f08094
+  checksum: 91ff179f0b9828a6880b6decaa8603fd7af0311f46a38d3a93647a2497298750d676810aeff533a335443a01a7b340dbba7c76523bcd7a87d7b05b7677742901
   languageName: node
   linkType: hard
 
@@ -24891,13 +24891,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.9.4, typescript@npm:^4.9.5":
+"typescript@npm:^4.9.4":
   version: 4.9.5
   resolution: "typescript@npm:4.9.5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "typescript@npm:5.0.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 3cce0576d218cb4277ff8b6adfef1a706e9114a98b4261a38ad658a7642f1b274a8396394f6cbff8c0ba852996d7ed2e233e9b8431d5d55ac7c2f6fea645af02
   languageName: node
   linkType: hard
 
@@ -24911,13 +24921,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.9.4#~builtin<compat/typescript>, typescript@patch:typescript@^4.9.5#~builtin<compat/typescript>":
+"typescript@patch:typescript@^4.9.4#~builtin<compat/typescript>":
   version: 4.9.5
   resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=ad5954"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 8f6260acc86b56bfdda6004bc53f32ea548f543e8baef7071c8e34d29d292f3e375c8416556c8de10b24deef6933cd1c16a8233dc84a3dd43a13a13265d0faab
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^5.0.3#~builtin<compat/typescript>":
+  version: 5.0.3
+  resolution: "typescript@patch:typescript@npm%3A5.0.3#~builtin<compat/typescript>::version=5.0.3&hash=ad5954"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 9ec0a8eed38d46cc2c8794555b7674e413604c56c159f71b8ff21ce7f17334a44127a68724cb2ef8221ff3b19369f8f05654e8a5266621d7d962aeed889bd630
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What is this about

This tiny PR updates all packages to use the latest `typescript` v5.0.3. As mentioned in the commit messages, `tsup` and `jest-mock-extended` also had to be updated to support Typescript 5.x.

Note, I had to run `yarn format` in 3 packages as `yarn check` revealed some Prettier formatting issues. Seems like some automation wasn't used previously or had been avoided. I didn't bother to git blame who committed but I'd recommend other contributors validate that oddly formatted code files get automatically formatted by Prettier on save or that we add `prettier --write` as a pre-commit hook.

## Issue ticket numbers

#190

## How can this be tested?

```sh
$ yarn run tsc --version
```

## Known limitations/edge cases

I didn't verify whether this affects the build in any way, only that types are still correct (`tsc --noEmit`). I'm counting on successful CI being enough validation.