### PR TITLE
Fix local coverage reporting using source maps with ESBuild

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,7 +1,16 @@
+/** @type {import('esbuild-jest').Options} */
+const esbuildOptions = {
+  // Setting `sourcemap` to `true` is needed[0] to correctly report line numbers
+  // in Jest's built-in coverage reporting.
+  //
+  // [0]: https://github.com/aelbore/esbuild-jest/issues/79
+  sourcemap: true,
+};
+
 /** @type {import('jest').Config} */
 const config = {
   transform: {
-    "^.+\\.tsx?$": "esbuild-jest",
+    "^.+\\.tsx?$": ["esbuild-jest", esbuildOptions],
   },
 };
 

--- a/packages/charlson-comorbidity-index/jest.config.cjs
+++ b/packages/charlson-comorbidity-index/jest.config.cjs
@@ -1,7 +1,16 @@
+/** @type {import('esbuild-jest').Options} */
+const esbuildOptions = {
+  // Setting `sourcemap` to `true` is needed[0] to correctly report line numbers
+  // in Jest's built-in coverage reporting.
+  //
+  // [0]: https://github.com/aelbore/esbuild-jest/issues/79
+  sourcemap: true,
+};
+
 /** @type {import('jest').Config} */
 const config = {
   transform: {
-    "^.+\\.tsx?$": "esbuild-jest",
+    "^.+\\.tsx?$": ["esbuild-jest", esbuildOptions],
   },
 };
 

--- a/packages/cmsdotgov/jest.config.cjs
+++ b/packages/cmsdotgov/jest.config.cjs
@@ -1,7 +1,16 @@
+/** @type {import('esbuild-jest').Options} */
+const esbuildOptions = {
+  // Setting `sourcemap` to `true` is needed[0] to correctly report line numbers
+  // in Jest's built-in coverage reporting.
+  //
+  // [0]: https://github.com/aelbore/esbuild-jest/issues/79
+  sourcemap: true,
+};
+
 /** @type {import('jest').Config} */
 const config = {
   transform: {
-    "^.+\\.tsx?$": "esbuild-jest",
+    "^.+\\.tsx?$": ["esbuild-jest", esbuildOptions],
   },
 };
 

--- a/packages/codegen/jest.config.cjs
+++ b/packages/codegen/jest.config.cjs
@@ -1,7 +1,16 @@
+/** @type {import('esbuild-jest').Options} */
+const esbuildOptions = {
+  // Setting `sourcemap` to `true` is needed[0] to correctly report line numbers
+  // in Jest's built-in coverage reporting.
+  //
+  // [0]: https://github.com/aelbore/esbuild-jest/issues/79
+  sourcemap: true,
+};
+
 /** @type {import('jest').Config} */
 const config = {
   transform: {
-    "^.+\\.tsx?$": "esbuild-jest",
+    "^.+\\.tsx?$": ["esbuild-jest", esbuildOptions],
   },
 };
 

--- a/packages/core/jest.config.cjs
+++ b/packages/core/jest.config.cjs
@@ -1,7 +1,16 @@
+/** @type {import('esbuild-jest').Options} */
+const esbuildOptions = {
+  // Setting `sourcemap` to `true` is needed[0] to correctly report line numbers
+  // in Jest's built-in coverage reporting.
+  //
+  // [0]: https://github.com/aelbore/esbuild-jest/issues/79
+  sourcemap: true,
+};
+
 /** @type {import('jest').Config} */
 const config = {
   transform: {
-    "^.+\\.tsx?$": "esbuild-jest",
+    "^.+\\.tsx?$": ["esbuild-jest", esbuildOptions],
   },
 };
 

--- a/packages/core/r4b/data-types/time.test.ts
+++ b/packages/core/r4b/data-types/time.test.ts
@@ -59,6 +59,20 @@ describe("fhirTimeTypeAdapter", () => {
         /Value does not match the fhir time format.*/
       );
     });
+
+    it("returns `undefined` when parsing unless the given value is a non-whitespace-only string", () => {
+      expect(adapter.parse(null)).toBeUndefined();
+      expect(adapter.parse(undefined)).toBeUndefined();
+      expect(adapter.parse("")).toBeUndefined();
+      expect(adapter.parse("\t\n ")).toBeUndefined();
+    });
+
+    it("returns an empty string when formatting unless the given value is a non-whitespace-only string", () => {
+      expect(adapter.format(null)).toStrictEqual("");
+      expect(adapter.format(undefined)).toStrictEqual("");
+      expect(adapter.format("")).toStrictEqual("");
+      expect(adapter.format("\t\n ")).toStrictEqual("");
+    });
   });
 
   describe("with an unknown locale", () => {

--- a/packages/core/r4b/data-types/time.test.ts
+++ b/packages/core/r4b/data-types/time.test.ts
@@ -10,7 +10,9 @@ describe("fhirTimeTypeAdapter", () => {
       });
 
       describe("parse", () => {
-        expect(adapter.parse("18:30:25")).toEqual("18:30:25");
+        it("correctly parses hours, minutes and seconds separated by colons", () => {
+          expect(adapter.parse("18:30:25")).toEqual("18:30:25");
+        });
       });
 
       describe("format", () => {

--- a/packages/fhir-query/jest.config.cjs
+++ b/packages/fhir-query/jest.config.cjs
@@ -1,8 +1,17 @@
+/** @type {import('esbuild-jest').Options} */
+const esbuildOptions = {
+  // Setting `sourcemap` to `true` is needed[0] to correctly report line numbers
+  // in Jest's built-in coverage reporting.
+  //
+  // [0]: https://github.com/aelbore/esbuild-jest/issues/79
+  sourcemap: true,
+};
+
 /** @type {import('jest').Config} */
 const config = {
   testEnvironment: "jsdom",
   transform: {
-    "^.+\\.tsx?$": "esbuild-jest",
+    "^.+\\.tsx?$": ["esbuild-jest", esbuildOptions],
   },
 };
 

--- a/packages/medplum/jest.config.cjs
+++ b/packages/medplum/jest.config.cjs
@@ -1,7 +1,16 @@
+/** @type {import('esbuild-jest').Options} */
+const esbuildOptions = {
+  // Setting `sourcemap` to `true` is needed[0] to correctly report line numbers
+  // in Jest's built-in coverage reporting.
+  //
+  // [0]: https://github.com/aelbore/esbuild-jest/issues/79
+  sourcemap: true,
+};
+
 /** @type {import('jest').Config} */
 const config = {
   transform: {
-    "^.+\\.tsx?$": "esbuild-jest",
+    "^.+\\.tsx?$": ["esbuild-jest", esbuildOptions],
   },
 };
 

--- a/packages/nih-nlm/jest.config.cjs
+++ b/packages/nih-nlm/jest.config.cjs
@@ -1,7 +1,16 @@
+/** @type {import('esbuild-jest').Options} */
+const esbuildOptions = {
+  // Setting `sourcemap` to `true` is needed[0] to correctly report line numbers
+  // in Jest's built-in coverage reporting.
+  //
+  // [0]: https://github.com/aelbore/esbuild-jest/issues/79
+  sourcemap: true,
+};
+
 /** @type {import('jest').Config} */
 const config = {
   transform: {
-    "^.+\\.tsx?$": "esbuild-jest",
+    "^.+\\.tsx?$": ["esbuild-jest", esbuildOptions],
   },
 };
 

--- a/packages/subscriptions/jest.config.cjs
+++ b/packages/subscriptions/jest.config.cjs
@@ -1,7 +1,16 @@
+/** @type {import('esbuild-jest').Options} */
+const esbuildOptions = {
+  // Setting `sourcemap` to `true` is needed[0] to correctly report line numbers
+  // in Jest's built-in coverage reporting.
+  //
+  // [0]: https://github.com/aelbore/esbuild-jest/issues/79
+  sourcemap: true,
+};
+
 /** @type {import('jest').Config} */
 const config = {
   transform: {
-    "^.+\\.tsx?$": "esbuild-jest",
+    "^.+\\.tsx?$": ["esbuild-jest", esbuildOptions],
   },
 };
 


### PR DESCRIPTION
## What is this about

This small change updates Jest configs to include source maps from ESBuild so that `jest --coverage` can accurately report line numbers in detailed which lines have or don't have coverage. Without source maps enabled, line numbers reported by `jest --coverage` are unhelpful.

Having this in place should allow a workflow like `yarn run test --coverage --watchAll` to give up-to-date coverage info on file save, making it easier to work towards better coverage.

## Issue ticket numbers

N/A

## How can this be tested?

To test that this works as intended run the following in any project with some amount of Jest test coverage:

```sh
$ yarn run test --coverage
```

and validate that the line numbers reported as uncovered point to real lines of implementation code that, if called during a test, will no longer be reported as missing coverage.

## Known limitations/edge cases

The export of source maps is purely for Jest test runs so there doesn't seem to be much affect on anything other than test runs. I ran the test suite (`yarn test`) at the top level with and without source maps enabled and cannot perceive a difference to the actual execution time.

> Note, now that Jest configurations for each project sharing much detail, we might want to consider adding a `jest-config` internal package to `packages/` to ensure they stay in sync and reduce needless config duplication. If this is agreeable, I'd recommend this be done in a separate PR however.