### PR TITLE
Feat-upgrade-medplum

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,6 @@
         "esbenp.prettier-vscode",
         "github.vscode-pull-request-github",
         "ms-azuretools.vscode-docker",
-        "nrwl.angular-console",
         "streetsidesoftware.code-spell-checker",
         "usernamehw.errorlens",
         "vivaxy.vscode-conventional-commits"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - devcontainer_command_history:/command_history
 
   medplum:
-    image: ghcr.io/bonfhir/medplum-devbox:v2.0.4
+    image: ghcr.io/bonfhir/medplum-devbox:v2.0.14
     depends_on:
       - postgres
       - redis

--- a/packages/charlson-comorbidity-index/package.json
+++ b/packages/charlson-comorbidity-index/package.json
@@ -21,7 +21,7 @@
     "@bonfhir/prettier-config": "^1.0.1-alpha.0",
     "@bonfhir/test-support": "^1.0.0-alpha.15",
     "@bonfhir/typescript-config": "^1.0.1-alpha.1",
-    "@medplum/core": "^2.0.7",
+    "@medplum/core": "2.0.14",
     "@types/fhir": "^0.0.35",
     "@types/node": "^18.15.3",
     "esbuild": "^0.17.12",

--- a/packages/cmsdotgov/package.json
+++ b/packages/cmsdotgov/package.json
@@ -20,7 +20,7 @@
     "@bonfhir/medplum": "^1.0.0-alpha.15",
     "@bonfhir/prettier-config": "^1.0.1-alpha.0",
     "@bonfhir/typescript-config": "^1.0.1-alpha.1",
-    "@medplum/core": "^2.0.7",
+    "@medplum/core": "2.0.14",
     "@types/fhir": "^0.0.35",
     "@types/node": "^18.15.3",
     "esbuild": "^0.17.12",

--- a/packages/docs/packages/foundation/core.md
+++ b/packages/docs/packages/foundation/core.md
@@ -89,7 +89,7 @@ This is a very common occurrence in data integration scenarios / syncing tasks.
 The `core` package provide a utility to help with those operations:
 
 ```typescript
-import { build, createOr, resourceSearch } from "@bonfhir/core/r4b";
+import { build, createOr } from "@bonfhir/core/r4b";
 import { KnownIdentifierSystems } from "@bonfhir/terminology/r4b";
 
 
@@ -131,7 +131,7 @@ The `searchAllPages` utility can be used to retrieve _all_ pages for a given sea
 > Be careful as this may be a very long / very expensive operation.
 
 ```typescript
-import { searchAllPages, resourceSearch, linkUrl } from "@bonfhir/core/r4b";
+import { searchAllPages, linkUrl } from "@bonfhir/core/r4b";
 
 const allActivePatients = await searchAllPages(client, "Patient", (search) =>
   search.active("true")
@@ -294,9 +294,8 @@ import {
   fhirSearch,
 } from "@bonfhir/core/r4b";
 
-const bundle = await client.search(
-  "Patient",
-  resourceSearch("Patient")
+const bundle = await client.search("Patient", (search) =>
+  search
     ._include("Patient", "managingOrganization")
     ._revinclude("Provenance", "target")
     ._include("Provenance", "agent", { iterate: true })

--- a/packages/fhir-query/package.json
+++ b/packages/fhir-query/package.json
@@ -20,7 +20,7 @@
     "@bonfhir/medplum": "^1.0.0-alpha.15",
     "@bonfhir/prettier-config": "^1.0.1-alpha.0",
     "@bonfhir/typescript-config": "^1.0.1-alpha.1",
-    "@medplum/core": "^2.0.7",
+    "@medplum/core": "2.0.14",
     "@tanstack/react-query": "^4.24.4",
     "@testing-library/react": "^13.4.0",
     "@types/fhir": "^0.0.35",

--- a/packages/medplum/package.json
+++ b/packages/medplum/package.json
@@ -19,7 +19,7 @@
     "@bonfhir/eslint-config": "^1.1.0-alpha.1",
     "@bonfhir/prettier-config": "^1.0.1-alpha.0",
     "@bonfhir/typescript-config": "^1.0.1-alpha.1",
-    "@medplum/core": "^2.0.7",
+    "@medplum/core": "2.0.14",
     "@types/node": "^18.15.3",
     "esbuild": "^0.17.12",
     "esbuild-jest": "^0.5.0",

--- a/packages/nih-nlm/package.json
+++ b/packages/nih-nlm/package.json
@@ -20,7 +20,7 @@
     "@bonfhir/medplum": "^1.0.0-alpha.15",
     "@bonfhir/prettier-config": "^1.0.1-alpha.0",
     "@bonfhir/typescript-config": "^1.0.1-alpha.1",
-    "@medplum/core": "^2.0.7",
+    "@medplum/core": "2.0.14",
     "@types/fhir": "^0.0.35",
     "@types/node": "^18.15.3",
     "esbuild": "^0.17.12",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -22,7 +22,7 @@
     "@bonfhir/prettier-config": "^1.0.1-alpha.0",
     "@bonfhir/typescript-config": "^1.0.1-alpha.1",
     "@ladle/react": "^2.10.1",
-    "@medplum/core": "^2.0.7",
+    "@medplum/core": "2.0.14",
     "@swc/core": "^1.3.41",
     "@swc/jest": "^0.2.24",
     "@tanstack/react-query": "^4.24.4",

--- a/samples/ehr-sample-app/package.json
+++ b/samples/ehr-sample-app/package.json
@@ -47,7 +47,7 @@
     "@bonfhir/medplum": "^1.0.0-alpha.9",
     "@bonfhir/terminology": "^1.0.0-alpha.3",
     "@bonfhir/ui-components": "^0.1.0-alpha.1",
-    "@medplum/core": "^2.0.7",
+    "@medplum/core": "2.0.14",
     "@tanstack/react-query": "^4.24.4",
     "@tanstack/react-query-devtools": "^4.24.4",
     "antd": "^5.1.7",

--- a/samples/sample-api-koa/package.json
+++ b/samples/sample-api-koa/package.json
@@ -38,7 +38,7 @@
     "@bonfhir/subscriptions": "^0.1.0-alpha.2",
     "@bonfhir/subscriptions-koa": "^0.1.0-alpha.1",
     "@koa/router": "^12.0.0",
-    "@medplum/core": "^2.0.7",
+    "@medplum/core": "2.0.14",
     "koa": "^2.14.1",
     "koa-bodyparser": "^4.4.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1978,7 +1978,7 @@ __metadata:
     "@bonfhir/prettier-config": ^1.0.1-alpha.0
     "@bonfhir/test-support": ^1.0.0-alpha.15
     "@bonfhir/typescript-config": ^1.0.1-alpha.1
-    "@medplum/core": ^2.0.7
+    "@medplum/core": 2.0.14
     "@types/fhir": ^0.0.35
     "@types/node": ^18.15.3
     esbuild: ^0.17.12
@@ -2003,7 +2003,7 @@ __metadata:
     "@bonfhir/prettier-config": ^1.0.1-alpha.0
     "@bonfhir/terminology": ^1.0.0-alpha.5
     "@bonfhir/typescript-config": ^1.0.1-alpha.1
-    "@medplum/core": ^2.0.7
+    "@medplum/core": 2.0.14
     "@types/fhir": ^0.0.35
     "@types/node": ^18.15.3
     csv-parse: ^5.3.6
@@ -2117,7 +2117,7 @@ __metadata:
     "@bonfhir/terminology": ^1.0.0-alpha.3
     "@bonfhir/typescript-config": ^1.0.1-alpha.0
     "@bonfhir/ui-components": ^0.1.0-alpha.1
-    "@medplum/core": ^2.0.7
+    "@medplum/core": 2.0.14
     "@tanstack/react-query": ^4.24.4
     "@tanstack/react-query-devtools": ^4.24.4
     "@testing-library/react": ^13.4.0
@@ -2168,7 +2168,7 @@ __metadata:
     "@bonfhir/medplum": ^1.0.0-alpha.15
     "@bonfhir/prettier-config": ^1.0.1-alpha.0
     "@bonfhir/typescript-config": ^1.0.1-alpha.1
-    "@medplum/core": ^2.0.7
+    "@medplum/core": 2.0.14
     "@tanstack/react-query": ^4.24.4
     "@testing-library/react": ^13.4.0
     "@types/fhir": ^0.0.35
@@ -2203,7 +2203,7 @@ __metadata:
     "@bonfhir/eslint-config": ^1.1.0-alpha.1
     "@bonfhir/prettier-config": ^1.0.1-alpha.0
     "@bonfhir/typescript-config": ^1.0.1-alpha.1
-    "@medplum/core": ^2.0.7
+    "@medplum/core": 2.0.14
     "@types/node": ^18.15.3
     esbuild: ^0.17.12
     esbuild-jest: ^0.5.0
@@ -2229,7 +2229,7 @@ __metadata:
     "@bonfhir/prettier-config": ^1.0.1-alpha.0
     "@bonfhir/terminology": ^1.0.0-alpha.5
     "@bonfhir/typescript-config": ^1.0.1-alpha.1
-    "@medplum/core": ^2.0.7
+    "@medplum/core": 2.0.14
     "@types/fhir": ^0.0.35
     "@types/node": ^18.15.3
     esbuild: ^0.17.12
@@ -2278,7 +2278,7 @@ __metadata:
     "@bonfhir/subscriptions-koa": ^0.1.0-alpha.1
     "@bonfhir/typescript-config": ^1.0.1-alpha.0
     "@koa/router": ^12.0.0
-    "@medplum/core": ^2.0.7
+    "@medplum/core": 2.0.14
     "@swc/core": ^1.3.41
     "@swc/jest": ^0.2.24
     "@types/fhir": ^0.0.35
@@ -2412,7 +2412,7 @@ __metadata:
     "@bonfhir/prettier-config": ^1.0.1-alpha.0
     "@bonfhir/typescript-config": ^1.0.1-alpha.1
     "@ladle/react": ^2.10.1
-    "@medplum/core": ^2.0.7
+    "@medplum/core": 2.0.14
     "@swc/core": ^1.3.41
     "@swc/jest": ^0.2.24
     "@tanstack/react-query": ^4.24.4
@@ -4555,15 +4555,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@medplum/core@npm:^2.0.7":
-  version: 2.0.7
-  resolution: "@medplum/core@npm:2.0.7"
+"@medplum/core@npm:2.0.14":
+  version: 2.0.14
+  resolution: "@medplum/core@npm:2.0.14"
   peerDependencies:
     pdfmake: ^0.2.5
   peerDependenciesMeta:
     pdfmake:
       optional: true
-  checksum: d01e6fc19e2a3b7dcaf69f5bdd3fc90070a2ea1e7e19a57785f4daca06b599b33ea571ad317b09e1a3607b3d2b605675d1ae8f2ebaac26d117e5b4992109c9ff
+  checksum: 2084a8edc100d3afa9d4263969388b83ad84136e31c63b0678048688775736fc8b8429a903c03d91793cfadbc2fc8d56934d0f6f00b971a2adb5e6082e96774d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What is this about

This is a housekeeping PR that:
 - upgrade medplum devbox to version 2.0.14
 - upgrade medplum client references to 2.0.14
 - fix a small issue with the `resourceSearch` documentation in `core`

## Issue ticket numbers

N/A

## How can this be tested?

N/A

## Known limitations/edge cases

N/A