### PR TITLE
build(core): :package: add browser option to allow direct CDN reference

### DIFF
--- a/packages/core/package.js
+++ b/packages/core/package.js
@@ -38,9 +38,10 @@ const execAsync = promisify(exec);
     .filter((dirent) => dirent.isDirectory())
     .map((dirent) => dirent.name)) {
     packageJson.exports[`./${packageRootDirName}`] = {
-      types: `./${packageRootDirName}/index.d.ts`,
-      require: `./${packageRootDirName}/index.cjs`,
       import: `./${packageRootDirName}/index.js`,
+      require: `./${packageRootDirName}/index.cjs`,
+      script: `./${packageRootDirName}/index.global.js`,
+      types: `./${packageRootDirName}/index.d.ts`,
       default: `./${packageRootDirName}/index.js`,
     };
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,7 @@
   "license": "APACHE-2.0",
   "type": "module",
   "scripts": {
-    "build": "yarn clean && tsup",
+    "build": "yarn clean && tsup  --config tsup.config.ts && tsup --config tsup-browser.config.ts",
     "check": "prettier --check ./**/*.ts && eslint ./**/*.ts && tsc --noEmit",
     "clean": "rimraf dist/",
     "codegen": "yarn workspace @bonfhir/codegen run dev run -d \"${PWD}/../../fhir/r4b/definitions/**/*.json\" -t \"${PWD}/r4b/**/*.hbs\" --helpers \"${PWD}/template-helpers.js\" -p 'prettier --write %files%'",

--- a/packages/core/r4b/global.ts
+++ b/packages/core/r4b/global.ts
@@ -1,0 +1,44 @@
+/**
+ * This module exists as an alternative entry-point to be able to directly reference the core library
+ * in a global import context, such as a browser.
+ * This enables usage in third-party tools such as no-code tools.
+ */
+
+import * as builders from "./builders";
+import * as bundleNavigator from "./bundle-navigator";
+import * as dataTypeAdapter from "./data-type-adapter";
+import * as date from "./date";
+import * as fhirRestfulClient from "./fhir-restful-client";
+import * as merge from "./merge";
+import * as narratives from "./narratives";
+import * as operationsParameters from "./operations-parameters";
+import * as periodCalculator from "./period-calculator";
+import * as resourcePatch from "./resource-patch";
+import * as resourceSearch from "./resource-search";
+import * as searchBuilder from "./search-builder";
+import * as types from "./types";
+import * as utils from "./utils";
+
+const bonfhirGlobals = {
+  ...builders,
+  ...bundleNavigator,
+  ...dataTypeAdapter,
+  ...date,
+  ...fhirRestfulClient,
+  ...merge,
+  ...narratives,
+  ...operationsParameters,
+  ...periodCalculator,
+  ...resourcePatch,
+  ...resourceSearch,
+  ...searchBuilder,
+  ...types,
+  ...utils,
+} as const;
+
+declare global {
+  // eslint-disable-next-line no-var
+  var bonfhir: typeof bonfhirGlobals;
+}
+
+globalThis.bonfhir = bonfhirGlobals;

--- a/packages/core/tsup-browser.config.ts
+++ b/packages/core/tsup-browser.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "r4b/global.ts",
+  },
+  format: ["iife"],
+  minify: true,
+  outDir: "dist/r4b",
+  shims: false,
+  dts: false,
+  tsconfig: "tsconfig.build.json",
+  noExternal: ["localized-address-format", "marked"],
+});


### PR DESCRIPTION
## What is this about

This PR adds a IIFE build with support for browsers.
This addition enable the usage of something like cdnjs or unpkg.
directly in the browser, and attach the functions to the window object.

This make is easy and convenient to use the features directly in a
browser, for example when using a no-code/low-code tool solution.

## Issue ticket numbers

N/A

## How can this be tested?

- Create an app in Retool.
- Add a reference to the library using unpkg:  https://unpkg.com/@bonfhir/core/r4b/index.global.js
- Use any function from the core in a transformer e.g. `bonfhir.intlFhirDataTypeAdapter()`

## Known limitations/edge cases

This covers some limited use case for the moment. We will have to think about the side-effect of the file addition to the package.
