### PR TITLE
Fix npiregistry import

### DIFF
--- a/packages/cmsdotgov/r4b/nppes/npiregistry-sync.ts
+++ b/packages/cmsdotgov/r4b/nppes/npiregistry-sync.ts
@@ -168,20 +168,22 @@ export class NPIRegistrySyncSession {
               address: this.mapNPIRegistryAddressesToAddresses(
                 npiResult.addresses
               ),
-              qualification: (npiResult.taxonomies || []).map(
-                (taxonomy): PractitionerQualification => ({
-                  id: `${this.stableId}-${taxonomy.code}`,
-                  code: buildCodeableConcept({
-                    coding: [
-                      {
-                        system: "https://npidb.org/taxonomy",
-                        code: taxonomy.code,
-                        display: taxonomy.desc,
-                      },
-                    ],
-                  }),
-                })
-              ),
+              qualification: (npiResult.taxonomies || [])
+                .filter((taxonomy) => !!taxonomy.code && !!taxonomy.desc)
+                .map(
+                  (taxonomy): PractitionerQualification => ({
+                    id: `${this.stableId}-${taxonomy.code}`,
+                    code: buildCodeableConcept({
+                      coding: [
+                        {
+                          system: "https://npidb.org/taxonomy",
+                          code: taxonomy.code,
+                          display: taxonomy.desc,
+                        },
+                      ],
+                    }),
+                  })
+                ),
             })
           )
         );

--- a/packages/core/r4b/merge.ts
+++ b/packages/core/r4b/merge.ts
@@ -137,6 +137,12 @@ function mergeFhirValues<T = any>({
 
   if (Array.isArray(current)) {
     if (!Array.isArray(incoming)) {
+      if (incoming == null) {
+        return mergeFhirResourcesArrays({
+          current,
+          incoming: [],
+        }) as MergeResult<T>;
+      }
       throw new Error("Can't merge a non-array value into an array.");
     }
 


### PR DESCRIPTION
## What is this about

This PR contains 2 bug fixes that surfaced during the NPI import process:
 - error when a practitioner taxonomy does not have a description set
 - error when saving a HealthcareService that surfaced a bug on array merge for null values.

## Issue ticket numbers

N/A

## How can this be tested?

Unit tests updated.

## Known limitations/edge cases

N/A
