### PR TITLE
175-Add a pattern option to the identifier data type adapter

### DIFF
--- a/packages/core/r4b/data-type-adapter.test.ts
+++ b/packages/core/r4b/data-type-adapter.test.ts
@@ -79,10 +79,13 @@ describe("intlFhirDataTypeAdapter", () => {
         systemsLabels: { "http://hl7.org/fhir/sid/us-ssn": "SSN (US)" },
       });
       expect(
-        adapter.identifier.format({
-          system: "http://hl7.org/fhir/sid/us-ssn",
-          value: "123456789",
-        })
+        adapter.identifier.format(
+          {
+            system: "http://hl7.org/fhir/sid/us-ssn",
+            value: "123456789",
+          },
+          { pattern: false }
+        )
       ).toEqual("SSN (US): 123456789");
     });
   });

--- a/packages/core/r4b/data-types/identifier.test.ts
+++ b/packages/core/r4b/data-types/identifier.test.ts
@@ -49,13 +49,14 @@ describe("fhirIdentifierTypeAdapter", () => {
         ]
       >
     >[
-      [identifier, undefined, "NAS: 123:456:789"],
+      [identifier, { pattern: false }, "NAS: 123:456:789"],
       [
         identifier,
         {
           style: "full",
           valueSetExpansions: animalsValueSetExpansion,
           systemsLabels: systemsLabels,
+          pattern: false,
         },
         "[10/11/2020 - ongoing]\nnumero de sécurité social: 123:456:789\nusual - list of code. (cat, dog, spider)",
       ],
@@ -65,10 +66,14 @@ describe("fhirIdentifierTypeAdapter", () => {
         medium: "NAS: 123:456:789 (usual)",
         short: "NAS: 123:456:789",
         value: "123:456:789",
-      }).map(([style, expected]) => [identifier, { style }, expected]),
+      }).map(([style, expected]) => [
+        identifier,
+        { style, pattern: false },
+        expected,
+      ]),
       [
         { system: "http://hl7.org/fhir/sid/us-ssn", value: "123456789" },
-        undefined,
+        { pattern: false },
         "SSN: 123456789",
       ],
     ])("parse %p with %p", (value, options, expected) => {
@@ -118,7 +123,10 @@ describe("fhirIdentifierTypeAdapter", () => {
 
     it("sorts by period and use", () => {
       expect(
-        fhirIdentifierTypeAdapter().format(identifiers, { style: "value" })
+        fhirIdentifierTypeAdapter().format(identifiers, {
+          style: "value",
+          pattern: false,
+        })
       ).toEqual(
         "usual, present, " +
           "temp, present, " +
@@ -135,6 +143,7 @@ describe("fhirIdentifierTypeAdapter", () => {
         fhirIdentifierTypeAdapter().format(identifiers, {
           useFilterOrder: ["official", "usual"],
           style: "value",
+          pattern: false,
         })
       ).toEqual(
         "usual, present, " +
@@ -158,6 +167,7 @@ describe("fhirIdentifierTypeAdapter", () => {
           useFilterOrder: ["official", "usual"],
           style: "value",
           max: 2,
+          pattern: false,
         })
       ).toEqual("usual, present and official, past");
     });
@@ -168,6 +178,136 @@ describe("fhirIdentifierTypeAdapter", () => {
       expect(() => fhirIdentifierTypeAdapter("nope")).toThrowError(
         "Incorrect locale information provided"
       );
+    });
+  });
+
+  describe("with a pattern", () => {
+    it("formats an identifier with the provided pattern", () => {
+      const identifier: Identifier = {
+        system: "http://hl7.org/fhir/sid/us-ssn",
+        value: "75359831",
+      };
+      expect(
+        fhirIdentifierTypeAdapter().format(identifier, {
+          pattern: "###-##-####",
+          style: "value",
+        })
+      ).toEqual("753-59-831");
+    });
+
+    it("formats an us-mbi identifier with the default us-mbi pattern", () => {
+      const identifier: Identifier = {
+        system: "http://hl7.org/fhir/sid/us-mbi",
+        value: "1EG4TE5MK73",
+      };
+
+      expect(
+        fhirIdentifierTypeAdapter().format(identifier, {
+          style: "value",
+        })
+      ).toEqual("1EG4-TE5-MK73");
+    });
+
+    it("formats an identifier with a custom system with a pattern in the record", () => {
+      const IdentifierPatterns: Record<string, string> = {
+        "http://hl7.org/fhir/sid/us-ssn": "###-#####",
+        "http://my-custom-identifier-system": "###-AA-BBB",
+        "https://fhir.nhs.uk/Id/nhs-number": "### ### ####",
+      };
+
+      const identifier: Identifier = {
+        system: "https://fhir.nhs.uk/Id/nhs-number",
+        value: "1234567890",
+      };
+
+      expect(
+        fhirIdentifierTypeAdapter().format(identifier, {
+          pattern: IdentifierPatterns,
+          style: "value",
+        })
+      ).toEqual("123 456 7890");
+    });
+
+    it("returns the original value if a default pattern is not found", () => {
+      const identifier: Identifier = {
+        system: "fake-system",
+        value: "1234567890",
+      };
+      expect(
+        fhirIdentifierTypeAdapter().format(identifier, {
+          style: "value",
+        })
+      ).toEqual("1234567890");
+    });
+
+    it("returns the original value if a custom pattern is not provided in the mapping", () => {
+      const identifier: Identifier = {
+        system: "fake-system",
+        value: "1234567890",
+      };
+
+      const pattern: Record<string, string> = {
+        "http://hl7.org/fhir/sid/us-ssn": "###-#####",
+        "http://my-custom-identifier-system": "###-AA-BBB",
+        "https://fhir.nhs.uk/Id/nhs-number": "### ### ####",
+      };
+      expect(
+        fhirIdentifierTypeAdapter().format(identifier, {
+          pattern,
+          style: "value",
+        })
+      ).toEqual("1234567890");
+    });
+
+    it("returns the original value if the pattern is an empty string", () => {
+      const identifier: Identifier = {
+        system: "http://hl7.org/fhir/sid/us-ssn",
+        value: "75359831",
+      };
+      expect(
+        fhirIdentifierTypeAdapter().format(identifier, {
+          pattern: "",
+          style: "value",
+        })
+      ).toEqual("75359831");
+    });
+
+    it("does nothing if already formatted", () => {
+      const identifier: Identifier = {
+        system: "http://hl7.org/fhir/sid/us-ssn",
+        value: "753-59-831",
+      };
+      expect(
+        fhirIdentifierTypeAdapter().format(identifier, {
+          style: "value",
+        })
+      ).toEqual("753-59-831");
+    });
+
+    it("formats with the systemPattern overiding the default pattern", () => {
+      const identifier: Identifier = {
+        system: "http://hl7.org/fhir/sid/us-ssn",
+        value: "12345678",
+      };
+      expect(
+        fhirIdentifierTypeAdapter().format(identifier, {
+          systemsPatterns: { "http://hl7.org/fhir/sid/us-ssn": "### ## ###" },
+          style: "value",
+        })
+      ).toEqual("123 45 678");
+    });
+
+    it("formats with escaping the patter characters", () => {
+      const identifier: Identifier = {
+        system: "http://hl7.org/fhir/sid/us-ssn",
+        value: "12345678",
+      };
+      expect(
+        fhirIdentifierTypeAdapter().format(identifier, {
+          pattern: `###\\##\\####`,
+          style: "value",
+        })
+      ).toEqual("123#45#678");
     });
   });
 });

--- a/packages/core/r4b/utils.ts
+++ b/packages/core/r4b/utils.ts
@@ -61,3 +61,37 @@ export function asArray<T>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return Array.isArray(value) ? (value as any) : [value];
 }
+
+/**
+ * Returns a formatted value based on the given `pattern` and `value`.
+ * If no pattern is provided, the value is returned as is.
+ * @param value - the value to format
+ * @param pattern - the pattern to use
+ * @returns the formatted value
+ */
+export function formatValueWithPattern(value: string, pattern: string): string {
+  if (!pattern) {
+    return value;
+  }
+
+  const patternChars = pattern.split("");
+  const valueChars = value.split("");
+
+  return patternChars
+    .map((char, i) => {
+      if (char === `\\` && patternChars[i + 1] === "#") {
+        return "#";
+      }
+      if (char === "#") {
+        const valueChar = valueChars.shift();
+        return valueChar;
+      }
+
+      if (char === valueChars[0]) {
+        return valueChars.shift();
+      }
+
+      return char;
+    })
+    .join("");
+}


### PR DESCRIPTION
## What is this about

A `pattern` control was added to the options object of the `fhirIdentifierTypeAdapter.format()` function. This pattern control was added to support mandatory display formats of FHIR identifiers. 

The supported values are:
- a string: `999-9*9-aaaa`
- a map: `{ "https://fhir.nhs.uk/Id/nhs-number": "999 999 9999" }`
- a boolean: `true` for default formatting

The default format characters are:
- `9` for numbers
- `a` for letters
- `*` for numbers and letters
Any other character will be used as a template.

The formatting function can be reused and is in [utils](https://github.com/bonfhir/bonfhir/pull/199/files#diff-b72391cd4891945ceafd5e7837e4f9b691b2389b29d966ee18746fc064b4b793).
<img width="642" alt="image" src="https://user-images.githubusercontent.com/13062328/234417190-0c98e7b2-3545-4fd8-ac97-6f504635d590.png">

## Issue ticket numbers

#175 

## How can this be tested?

`yarn run test`

## Known limitations/edge cases

As of right now, the formatting is `at best`. It provides flexibility for custom patterning. Some limitations can be introduced  if we want to reject patterns (returning the original value)

<img width="544" alt="image" src="https://user-images.githubusercontent.com/13062328/234418333-78c51eb3-dcf9-403f-8994-497d48baa9a7.png">
